### PR TITLE
HIMAN-329: Short circuit coordinate transformation logic

### DIFF
--- a/himan-lib/include/grid.h
+++ b/himan-lib/include/grid.h
@@ -156,6 +156,13 @@ class grid
 
 	virtual earth_shape<double> EarthShape() const = 0;
 
+	/**
+	 * @brief Create a list of point locations for a grid in the grids native coordinate system
+	 *
+	 */
+
+	virtual std::vector<point> GridPointsInProjectionSpace() const;
+
    protected:
 	grid(HPGridClass gridClass, HPGridType gridType, bool itsUVRelativeToGrid);
 
@@ -210,7 +217,18 @@ class regular_grid : public grid
 
 	/* Return grid point value (incl. fractions) of a given latlon point */
 	virtual point XY(const point& latlon) const;
+
+	/* Return grid point value (location) of a given target grid */
+	virtual std::vector<point> XY(const regular_grid& to) const;
+
+	/* Return latitude-longitude value for a given location index */
 	virtual point LatLon(size_t i) const override;
+
+	/* Return latitude-longitude value for a given point in projected space */
+	virtual point LatLon(const point& projected) const;
+
+	/* Return projected value for a given latitude-longitude point */
+	virtual point Projected(const point& latlon) const;
 
 	/*
 	 * Functions that are only valid for some grid types, but for ease
@@ -237,7 +255,8 @@ class regular_grid : public grid
 	virtual std::unique_ptr<OGRPolygon> Geometry() const;
 	virtual earth_shape<double> EarthShape() const override;
 
-	std::unique_ptr<OGRSpatialReference> SpatialReference() const;
+	virtual std::unique_ptr<OGRSpatialReference> SpatialReference() const;
+	virtual std::vector<point> GridPointsInProjectionSpace() const override;
 
    protected:
 	regular_grid(HPGridType gridType, HPScanningMode scMode, double di, double dj, size_t ni, size_t nj,

--- a/himan-lib/include/interpolate.h
+++ b/himan-lib/include/interpolate.h
@@ -120,7 +120,11 @@ template <typename T>
 std::pair<std::vector<size_t>, std::vector<T>> InterpolationWeights(reduced_gaussian_grid& source, point target);
 
 template <typename T>
-std::pair<std::vector<size_t>, std::vector<T>> InterpolationWeights(regular_grid& source, point target);
+std::pair<std::vector<size_t>, std::vector<T>> InterpolationWeights(const regular_grid& source, const point& target);
+
+template <typename T>
+std::vector<std::pair<std::vector<size_t>, std::vector<T>>> InterpolationWeights(const regular_grid& source,
+                                                                                 const std::vector<point>& targets);
 
 /**
  * @brief Provide the nearest point index for a single target point with weight 1.0
@@ -132,7 +136,10 @@ template <typename T>
 std::pair<size_t, T> NearestPoint(reduced_gaussian_grid& source, point target);
 
 template <typename T>
-std::pair<size_t, T> NearestPoint(const regular_grid& source, point target);
+std::pair<size_t, T> NearestPoint(const regular_grid& source, const point& target);
+
+template <typename T>
+std::vector<std::pair<size_t, T>> NearestPoint(const regular_grid& source, const std::vector<point>& targets);
 }
 }
 

--- a/himan-lib/include/latitude_longitude_grid.h
+++ b/himan-lib/include/latitude_longitude_grid.h
@@ -50,7 +50,10 @@ class latitude_longitude_grid : public regular_grid
 	bool operator!=(const grid& other) const;
 
 	point XY(const point& latlon) const override;
+	std::vector<point> XY(const regular_grid& target) const override;
 	point LatLon(size_t locationIndex) const override;
+	point LatLon(const point& projected) const override;
+	virtual point Projected(const point& latlon) const override;
 
 	size_t Hash() const override;
 
@@ -58,6 +61,9 @@ class latitude_longitude_grid : public regular_grid
 
 	virtual std::string Proj4String() const override;
 	virtual earth_shape<double> EarthShape() const override;
+
+	virtual std::unique_ptr<OGRSpatialReference> SpatialReference() const override;
+	virtual std::vector<point> GridPointsInProjectionSpace() const override;
 
    protected:
 	bool EqualsTo(const latitude_longitude_grid& other) const;
@@ -128,16 +134,21 @@ class rotated_latitude_longitude_grid : public latitude_longitude_grid
 	point FirstPoint() const override;
 	// return grid xy coordinates for normal latlon
 	point XY(const point& latlon) const override;
+	std::vector<point> XY(const regular_grid& target) const override;
 	// return latlon for grid running index
 	point LatLon(size_t locationIndex) const override;
+	point LatLon(const point& rotated) const override;
+
 	// return rotated point for grid running index
 	point RotatedLatLon(size_t locationIndex) const;
 	// return rotated point for normal latlon
 	point Rotate(const point& latlon) const;
+	virtual point Projected(const point& latlon) const override;
 
 	size_t Hash() const override;
 
 	virtual std::string Proj4String() const override;
+	virtual std::unique_ptr<OGRSpatialReference> SpatialReference() const override;
 
    private:
 	bool EqualsTo(const rotated_latitude_longitude_grid& other) const;

--- a/himan-lib/source/grid.cpp
+++ b/himan-lib/source/grid.cpp
@@ -82,7 +82,7 @@ void grid::UVRelativeToGrid(bool theUVRelativeToGrid)
 }
 std::vector<point> grid::GridPointsInProjectionSpace() const
 {
-	throw runtime_error("grid::GridPointInProjectionSpace() called");
+	throw runtime_error("grid::GridPointsInProjectionSpace() called");
 }
 
 //--------------- regular grid

--- a/himan-lib/source/grid.cpp
+++ b/himan-lib/source/grid.cpp
@@ -80,6 +80,10 @@ void grid::UVRelativeToGrid(bool theUVRelativeToGrid)
 {
 	itsUVRelativeToGrid = theUVRelativeToGrid;
 }
+std::vector<point> grid::GridPointsInProjectionSpace() const
+{
+	throw runtime_error("grid::GridPointInProjectionSpace() called");
+}
 
 //--------------- regular grid
 
@@ -212,12 +216,12 @@ std::string regular_grid::Proj4String() const
 	return proj;
 }
 
-point regular_grid::XY(const point& latlon) const
+point regular_grid::Projected(const point& latlon) const
 {
 	double projX = latlon.X(), projY = latlon.Y();
 	ASSERT(itsLatLonToXYTransformer);
 
-	// 1. Transform latlon to projected coordinates.
+	// Transform latlon to projected coordinates.
 	// Projected coordinates are in meters, with false easting and
 	// false northing applied so that point 0,0 is top left or bottom left,
 	// depending on the scanning mode.
@@ -229,16 +233,40 @@ point regular_grid::XY(const point& latlon) const
 		return point();
 	}
 
+	return point(projX, projY);
+}
+
+point regular_grid::XY(const point& latlon) const
+{
+	// 1. Get latlon point in projected space
+	const point proj = Projected(latlon);
+
 	// 2. Transform projected coordinates (meters) to grid xy (no unit).
 	// Projected coordinates run from 0 ... area width and 0 ... area height.
 	// Grid point coordinates run from 0 ... ni and 0 ... nj.
 
-	const double x = (projX / itsDi);
-	const double y = (projY / itsDj) * (itsScanningMode == kTopLeft ? -1 : 1);
+	const double x = (proj.X() / itsDi);
+	const double y = (proj.Y() / itsDj) * (itsScanningMode == kTopLeft ? -1 : 1);
 
 	if (x < 0. || x > static_cast<double>(itsNi - 1) || y < 0. || y > static_cast<double>(itsNj - 1))
 	{
 		return point(MissingDouble(), MissingDouble());
+	}
+
+	return point(x, y);
+}
+
+point regular_grid::LatLon(const point& projected) const
+{
+	double x = projected.X();
+	double y = projected.Y();
+
+	ASSERT(itsXYToLatLonTransformer);
+	if (!itsXYToLatLonTransformer->Transform(1, &x, &y))
+	{
+		itsLogger.Error("Error determining latitude longitude value for xy point " + std::to_string(x) + "," +
+		                std::to_string(y));
+		return point();
 	}
 
 	return point(x, y);
@@ -256,15 +284,7 @@ point regular_grid::LatLon(size_t locationIndex) const
 	double x = static_cast<double>(iIndex) * itsDi;
 	double y = static_cast<double>(jIndex) * itsDj * (itsScanningMode == kTopLeft ? -1 : 1);
 
-	ASSERT(itsXYToLatLonTransformer);
-	if (!itsXYToLatLonTransformer->Transform(1, &x, &y))
-	{
-		itsLogger.Error("Error determining latitude longitude value for xy point " + std::to_string(x) + "," +
-		                std::to_string(y));
-		return point();
-	}
-
-	return point(x, y);
+	return LatLon(point(x, y));
 }
 
 size_t regular_grid::Size() const
@@ -291,7 +311,8 @@ point regular_grid::BottomLeft() const
 		case kTopLeft:
 			return LatLon(itsNj * itsNi - itsNi);
 		default:
-			throw runtime_error("Unhandled scanning mode: " + HPScanningModeToString.at(itsScanningMode));
+			itsLogger.Fatal(fmt::format("Unhandled scanning mode: {}", HPScanningModeToString.at(itsScanningMode)));
+			himan::Abort();
 	}
 }
 point regular_grid::TopRight() const
@@ -303,7 +324,8 @@ point regular_grid::TopRight() const
 		case kTopLeft:
 			return LatLon(itsNi - 1);
 		default:
-			throw runtime_error("Unhandled scanning mode: " + HPScanningModeToString.at(itsScanningMode));
+			itsLogger.Fatal(fmt::format("Unhandled scanning mode: {}", HPScanningModeToString.at(itsScanningMode)));
+			himan::Abort();
 	}
 }
 point regular_grid::TopLeft() const
@@ -315,7 +337,8 @@ point regular_grid::TopLeft() const
 		case kTopLeft:
 			return LatLon(0);
 		default:
-			throw runtime_error("Unhandled scanning mode: " + HPScanningModeToString.at(itsScanningMode));
+			itsLogger.Fatal(fmt::format("Unhandled scanning mode: {}", HPScanningModeToString.at(itsScanningMode)));
+			himan::Abort();
 	}
 }
 point regular_grid::BottomRight() const
@@ -327,7 +350,8 @@ point regular_grid::BottomRight() const
 		case kTopLeft:
 			return LatLon(itsNi * itsNj - 1);
 		default:
-			throw runtime_error("Unhandled scanning mode: " + HPScanningModeToString.at(itsScanningMode));
+			itsLogger.Fatal(fmt::format("Unhandled scanning mode: {}", HPScanningModeToString.at(itsScanningMode)));
+			himan::Abort();
 	}
 }
 
@@ -354,14 +378,16 @@ earth_shape<double> regular_grid::EarthShape() const
 
 	if (err != OGRERR_NONE)
 	{
-		throw runtime_error("Unable to get Semi Major");
+		itsLogger.Fatal("Unable to get Semi Major");
+		himan::Abort();
 	}
 
 	const double B = itsSpatialReference->GetSemiMinor(&err);
 
 	if (err != OGRERR_NONE)
 	{
-		throw runtime_error("Unable to get Semi Minor");
+		itsLogger.Fatal("Unable to get Semi Minor");
+		himan::Abort();
 	}
 
 	return earth_shape<double>(A, B);
@@ -432,6 +458,85 @@ std::unique_ptr<OGRPolygon> regular_grid::Geometry() const
 std::unique_ptr<OGRSpatialReference> regular_grid::SpatialReference() const
 {
 	return std::unique_ptr<OGRSpatialReference>(itsSpatialReference->Clone());
+}
+
+std::vector<point> regular_grid::GridPointsInProjectionSpace() const
+{
+	std::vector<point> ret;
+	ret.reserve(Size());
+
+	point first = Projected(FirstPoint());
+
+	const double dj = itsDj * (itsScanningMode == kTopLeft ? -1 : 1);
+
+	for (size_t y = 0; y < Nj(); y++)
+	{
+		for (size_t x = 0; x < Ni(); x++)
+		{
+			ret.emplace_back(fma(static_cast<double>(x), itsDi, first.X()), fma(static_cast<double>(y), dj, first.Y()));
+		}
+	}
+
+	return ret;
+}
+
+std::vector<point> regular_grid::XY(const regular_grid& target) const
+{
+	// 1. Create list of points in the projection space of the
+	// target grid.
+
+	const auto targetProj = target.GridPointsInProjectionSpace();
+
+	// 2. Transform the points to the projection space of the source
+	// grid
+
+	auto tosp = target.SpatialReference();
+	const point soff = Projected(FirstPoint());
+
+	vector<point> sourceProj;
+
+	if (itsSpatialReference->IsSame(tosp.get()))
+	{
+		sourceProj = targetProj;
+	}
+	else
+	{
+		sourceProj.reserve(targetProj.size());
+
+		auto xform = std::unique_ptr<OGRCoordinateTransformation>(
+		    OGRCreateCoordinateTransformation(target.SpatialReference().get(), itsSpatialReference.get()));
+
+		for (const auto& p : targetProj)
+		{
+			double x = p.X(), y = p.Y();
+
+			if (!xform->Transform(1, &x, &y))
+				himan::Abort();
+			sourceProj.emplace_back(x, y);
+		}
+	}
+
+	// 3. Transform projected coordinates to grid space
+
+	const double ni = static_cast<double>(itsNi - 1);
+	const double nj = static_cast<double>(itsNj - 1);
+	const double di = itsDi;
+	const double dj = itsDj * (itsScanningMode == kTopLeft ? -1 : 1);
+
+	std::vector<point> sourceXY;
+	sourceXY.reserve(sourceProj.size());
+
+	for (auto& p : sourceProj)
+	{
+		double x = (p.X() - soff.X()) / di, y = (p.Y() - soff.Y()) / dj;
+
+		if (x < 0. || x > ni || y < 0. || y > nj)
+		{
+			x = y = MissingDouble();
+		}
+		sourceXY.emplace_back(x, y);
+	}
+	return sourceXY;
 }
 
 //--------------- irregular grid

--- a/himan-lib/source/interpolate.cpp
+++ b/himan-lib/source/interpolate.cpp
@@ -698,10 +698,8 @@ std::pair<std::vector<size_t>, std::vector<T>> InterpolationWeights(reduced_gaus
 }
 
 template <typename T>
-std::pair<std::vector<size_t>, std::vector<T>> InterpolationWeights(regular_grid& source, point target)
+std::pair<std::vector<size_t>, std::vector<T>> InterpolationWeights(const regular_grid& source, const point& xy)
 {
-	auto xy = source.XY(target);
-
 	if (IsMissing(xy.X()) || IsMissing(xy.Y()))
 		return std::make_pair(std::vector<size_t>{0}, std::vector<T>{MissingValue<T>()});
 
@@ -730,6 +728,21 @@ std::pair<std::vector<size_t>, std::vector<T>> InterpolationWeights(regular_grid
 	}
 
 	return std::make_pair(idxs, weights);
+}
+
+template <typename T>
+std::vector<std::pair<std::vector<size_t>, std::vector<T>>> InterpolationWeights(const regular_grid& source,
+                                                                                 const std::vector<point>& targets)
+{
+	std::vector<std::pair<std::vector<size_t>, std::vector<T>>> ret;
+	ret.reserve(targets.size());
+
+	for (const auto& xy : targets)
+	{
+		ret.push_back(InterpolationWeights<T>(source, xy));
+	}
+
+	return ret;
 }
 
 template <typename T>
@@ -772,12 +785,12 @@ std::pair<size_t, T> NearestPoint(reduced_gaussian_grid& source, point target)
 }
 
 template <typename T>
-std::pair<size_t, T> NearestPoint(const regular_grid& source, point target)
+std::pair<size_t, T> NearestPoint(const regular_grid& source, const point& xy)
 {
-	auto xy = source.XY(target);
 	if (IsMissing(xy.X()) || IsMissing(xy.Y()))
+	{
 		return std::make_pair(0, MissingValue<T>());
-
+	}
 	// In case of point in wrap-around region on global grid
 	if (static_cast<size_t>(std::round(xy.X())) == source.Ni())
 	{
@@ -787,64 +800,132 @@ std::pair<size_t, T> NearestPoint(const regular_grid& source, point target)
 	    static_cast<size_t>(std::round(xy.X())) + source.Ni() * static_cast<size_t>(std::round(xy.Y())), 1.0);
 }
 
+template <typename T>
+std::vector<std::pair<size_t, T>> NearestPoint(const regular_grid& source, const std::vector<point>& targets)
+{
+	std::vector<std::pair<size_t, T>> ret;
+	ret.reserve(targets.size());
+
+	for (const auto& xy : targets)
+	{
+		ret.push_back(NearestPoint<T>(source, xy));
+	}
+
+	return ret;
+}
+
 // area_interpolation class member functions definitions
 template <typename T>
 area_interpolation<T>::area_interpolation(grid& source, grid& target, HPInterpolationMethod method)
     : itsInterpolation(target.Size(), source.Size())
 {
 	std::vector<Triplet<T>> coefficients;
-	// compute weights in the interpolation matrix line by line, i.e. point by point on target grid
-	for (size_t i = 0; i < target.Size(); ++i)
+
+	std::string useOldMethod = "no";
+	try
 	{
-		std::pair<std::vector<size_t>, std::vector<T>> w;
-		switch (source.Type())
+		useOldMethod = util::GetEnv("HIMAN_USE_OLD_PROJECTION_METHOD");
+	}
+	catch (...)
+	{
+	}
+
+	// default to using new 'bulk' method
+	if (source.Class() == target.Class() && source.Class() == kRegularGrid && useOldMethod == "no")
+	{
+		const regular_grid& sg = dynamic_cast<regular_grid&>(source);
+		const regular_grid& tg = dynamic_cast<regular_grid&>(target);
+
+		std::vector<point> xy = sg.XY(tg);
+		std::vector<std::pair<std::vector<size_t>, std::vector<T>>> ws;
+
+		if (method == kBiLinear)
 		{
-			case kLatitudeLongitude:
-			case kRotatedLatitudeLongitude:
-			case kStereographic:
-			case kLambertConformalConic:
-			case kLambertEqualArea:
-			case kTransverseMercator:
-				if (method == kBiLinear)
-				{
-					w = InterpolationWeights<T>(dynamic_cast<regular_grid&>(source), target.LatLon(i));
-				}
-				else if (method == kNearestPoint)
-				{
-					auto np = NearestPoint<T>(dynamic_cast<regular_grid&>(source), target.LatLon(i));
-					w.first.push_back(np.first);
-					w.second.push_back(np.second);
-				}
-				else
-				{
-					throw std::bad_typeid();
-				}
-				break;
-			case kReducedGaussian:
-				if (method == kBiLinear)
-				{
-					w = InterpolationWeights<T>(dynamic_cast<reduced_gaussian_grid&>(source), target.LatLon(i));
-				}
-				else if (method == kNearestPoint)
-				{
-					auto np = NearestPoint<T>(dynamic_cast<reduced_gaussian_grid&>(source), target.LatLon(i));
-					w.first.push_back(np.first);
-					w.second.push_back(np.second);
-				}
-				else
-				{
-					throw std::bad_typeid();
-				}
-				break;
-			default:
-				// what to throw?
-				throw std::bad_typeid();
-				break;
+			ws = InterpolationWeights<T>(sg, xy);
+		}
+		else if (method == kNearestPoint)
+		{
+			auto np = NearestPoint<T>(sg, xy);
+
+			for (size_t i = 0; i < np.size(); i++)
+			{
+				std::pair<std::vector<size_t>, std::vector<T>> w;
+				w.first.push_back(np[i].first);
+				w.second.push_back(np[i].second);
+				ws.push_back(w);
+			}
+		}
+		else
+		{
+			throw std::bad_typeid();
 		}
 
-		for (size_t j = 0; j < w.first.size(); ++j)
+		for (size_t i = 0; i < ws.size(); i++)
 		{
-			coefficients.push_back(Triplet<T>(static_cast<int>(i), static_cast<int>(w.first[j]), w.second[j]));
+			const auto& w = ws[i];
+			for (size_t j = 0; j < w.first.size(); ++j)
+			{
+				coefficients.push_back(Triplet<T>(static_cast<int>(i), static_cast<int>(w.first[j]), w.second[j]));
+			}
+		}
+	}
+	else
+	{
+		// compute weights in the interpolation matrix line by line, i.e. point by point on target grid
+		for (size_t i = 0; i < target.Size(); ++i)
+		{
+			std::pair<std::vector<size_t>, std::vector<T>> w;
+			switch (source.Type())
+			{
+				case kLatitudeLongitude:
+				case kRotatedLatitudeLongitude:
+				case kStereographic:
+				case kLambertConformalConic:
+				case kLambertEqualArea:
+				case kTransverseMercator:
+					if (method == kBiLinear)
+					{
+						w = InterpolationWeights<T>(dynamic_cast<regular_grid&>(source),
+						                            dynamic_cast<regular_grid&>(source).XY(target.LatLon(i)));
+					}
+					else if (method == kNearestPoint)
+					{
+						auto np = NearestPoint<T>(dynamic_cast<regular_grid&>(source),
+						                          dynamic_cast<regular_grid&>(source).XY(target.LatLon(i)));
+						w.first.push_back(np.first);
+						w.second.push_back(np.second);
+					}
+					else
+					{
+						throw std::bad_typeid();
+					}
+					break;
+				case kReducedGaussian:
+					if (method == kBiLinear)
+					{
+						w = InterpolationWeights<T>(dynamic_cast<reduced_gaussian_grid&>(source), target.LatLon(i));
+					}
+					else if (method == kNearestPoint)
+					{
+						auto np = NearestPoint<T>(dynamic_cast<reduced_gaussian_grid&>(source), target.LatLon(i));
+						w.first.push_back(np.first);
+						w.second.push_back(np.second);
+					}
+					else
+					{
+						throw std::bad_typeid();
+					}
+					break;
+				default:
+					// what to throw?
+					throw std::bad_typeid();
+					break;
+			}
+
+			for (size_t j = 0; j < w.first.size(); ++j)
+			{
+				coefficients.push_back(Triplet<T>(static_cast<int>(i), static_cast<int>(w.first[j]), w.second[j]));
+			}
 		}
 	}
 


### PR DESCRIPTION
Himan transforms coordinates between projections (with gdal) using latlon
as an intermediate representation. This introduces some very small numerical
inaccuracies, which eventually push some valid grid points outside the grid
in some circumstances.

Introduce a "bulk" transformation method where coordinate transformation is
done directly from source to target utilizing gdal methods. Implemented only
for regular grids.