### PR TITLE
Add additional capability to handle missing values in ensembles

### DIFF
--- a/doc/plugin-fractile.md
+++ b/doc/plugin-fractile.md
@@ -54,6 +54,10 @@ fractiles: which set of fractiles to calculate.
 
     "fractiles" : "100,90,75,50,25,20,10,0"
 
+missing_value_treatment: how to deal with missing values in the ensemble. Options are "remove" (default), "first" or "last".
+
+    "missing_value_treatment" : "last"
+
 ensemble_type: define the type of ensemble. Currently supported are:
 
 * the traditional ensemble with multiple perturbed forecasts

--- a/himan-lib/include/ensemble.h
+++ b/himan-lib/include/ensemble.h
@@ -22,6 +22,13 @@ enum HPEnsembleType
 	kLaggedEnsemble
 };
 
+enum HPMissingValueTreatment
+{
+	kRemove = 0,
+	kFirst,
+	kLast
+};
+
 const std::unordered_map<HPEnsembleType, std::string> HPEnsembleTypeToString = {
     {kUnknownEnsembleType, "unknown"},
     {kPerturbedEnsemble, "perturbed ensemble"},
@@ -35,6 +42,11 @@ const std::unordered_map<std::string, HPEnsembleType> HPStringToEnsembleType = {
     {"time ensemble", kTimeEnsemble},
     {"level ensemble", kLevelEnsemble},
     {"lagged ensemble", kLaggedEnsemble}};
+
+const std::unordered_map<std::string, HPMissingValueTreatment> HPStringToMissingValueTreatment = {
+    {"remove", kRemove},
+    {"first", kFirst},
+    {"last", kLast}};
 
 // ensemble is a thin layer on top of the usual himan data utilities.
 // It is used to make working with ensemble forecasts a bit nicer and
@@ -81,7 +93,10 @@ class ensemble
 	std::vector<float> Values() const;
 
 	/// @brief Returns the current values of the ensemble sorted in increasing order, missing values are removed
-	std::vector<float> SortedValues() const;
+        std::vector<float> SortedValues() const;
+
+	/// @brief Returns the current values of the ensemble sorted in increasing order, missing values are removed
+	std::vector<float> SortedValues(const HPMissingValueTreatment) const;
 
 	/// @brief Returns the mean value of the ensemble
 	float Mean() const;

--- a/himan-lib/source/ensemble.cpp
+++ b/himan-lib/source/ensemble.cpp
@@ -129,8 +129,8 @@ void ensemble::VerifyValidForecastCount(int numMissingForecasts)
 			throw kFileDataNotFound;
 		}
 	}
-	// Normally, we don't except any of the fields to be missing, but at this point
-	// we've already catched the exceptions
+	// Normally, we don't expect any of the fields to be missing, but at this point
+	// we've already caught the exceptions
 	else
 	{
 		if (numMissingForecasts > 0)
@@ -197,12 +197,21 @@ std::vector<float> ensemble::SortedValues(const HPMissingValueTreatment treatMis
 	std::vector<float> res;
 	switch (treatMissing)
 	{
+		// The base case covers data where there usually are no missing values expected to be in the data
+		// or where they are not meaningful for example in temperature fields where missing values should
+		// be ignored and products like fractiles be computed from a reduced ensemble
 		case kRemove:
 			{
 				res = RemoveMissingValues(Values());
 				std::sort(res.begin(), res.end());
 				break;
 			}
+		// For some parameters missing values are used to indicate absence of the parameter, e.g. cloud
+		// base height that is only meaningful when there are clouds. Cloud free cases are marked as
+		// missing value. If we want remove missing values in this case the fractiles would always indicate
+		// high probabilities for cloud base so we don't want to reduce the ensemble here. Instead we move
+		// the missing values to the end of the sorted ensemble so they would resemble infinite cloude base
+		// height
 		case kLast:
 			{
 				std::vector<float> val = Values();
@@ -213,6 +222,8 @@ std::vector<float> ensemble::SortedValues(const HPMissingValueTreatment treatMis
 				std::copy(v.begin(), v.end(), res.begin());
 				break;
 			}
+		// This might be useful for similar reasons than kLast except that the missing value would be
+		// representing infinite negative numbers in the sorting.
 		case kFirst:
 			{
 				std::vector<float> val = Values();

--- a/himan-lib/source/ensemble.cpp
+++ b/himan-lib/source/ensemble.cpp
@@ -197,9 +197,9 @@ std::vector<float> ensemble::SortedValues(const HPMissingValueTreatment treatMis
 	std::vector<float> res;
 	switch (treatMissing)
 	{
-		// The base case covers data where there usually are no missing values expected to be in the data
-		// or where they are not meaningful for example in temperature fields where missing values should
-		// be ignored and products like fractiles be computed from a reduced ensemble
+		// The base case covers data where there usually are no missing values expected to be found in the 
+		// data or where they are not meaningful, e.g. in temperature fields where missing values should
+		// be ignored and products like fractiles be computed from a reduced ensemble.
 		case kRemove:
 			{
 				res = RemoveMissingValues(Values());
@@ -208,10 +208,10 @@ std::vector<float> ensemble::SortedValues(const HPMissingValueTreatment treatMis
 			}
 		// For some parameters missing values are used to indicate absence of the parameter, e.g. cloud
 		// base height that is only meaningful when there are clouds. Cloud free cases are marked as
-		// missing value. If we want remove missing values in this case the fractiles would always indicate
-		// high probabilities for cloud base so we don't want to reduce the ensemble here. Instead we move
-		// the missing values to the end of the sorted ensemble so they would resemble infinite cloude base
-		// height
+		// missing value. If we would remove missing values in this case the fractiles would always indicate
+		// high probabilities for cloud base so we don't want to reduce the ensemble size here. Instead 
+		// we move the missing values to the end of the sorted ensemble so they would resemble infinite 
+		// cloude base height.
 		case kLast:
 			{
 				std::vector<float> val = Values();

--- a/himan-lib/source/ensemble.cpp
+++ b/himan-lib/source/ensemble.cpp
@@ -189,9 +189,47 @@ std::vector<float> ensemble::Values() const
 
 std::vector<float> ensemble::SortedValues() const
 {
-	std::vector<float> v = RemoveMissingValues(Values());
-	std::sort(v.begin(), v.end());
-	return v;
+	return SortedValues(kRemove);
+}
+
+std::vector<float> ensemble::SortedValues(const HPMissingValueTreatment treatMissing) const
+{
+	std::vector<float> res;
+	switch (treatMissing)
+	{
+		case kRemove:
+			{
+				res = RemoveMissingValues(Values());
+				std::sort(res.begin(), res.end());
+				break;
+			}
+		case kLast:
+			{
+				std::vector<float> val = Values();
+				std::vector<float> v = RemoveMissingValues(val);
+				std::sort(v.begin(), v.end());
+
+				res = std::vector<float>(val.size(), himan::MissingFloat());
+				std::copy(v.begin(), v.end(), res.begin());
+				break;
+			}
+		case kFirst:
+			{
+				std::vector<float> val = Values();
+				std::vector<float> v = RemoveMissingValues(val);
+				std::sort(v.begin(), v.end());
+
+				res = std::vector<float>(val.size(), himan::MissingFloat());
+				std::copy(v.begin(), v.end(), std::back_inserter(res));
+				break;
+			}
+		default:
+			{
+				itsLogger.Fatal("Undefined behaviour for missing value treatment");
+                                himan::Abort();
+			}
+	}
+	return res;
 }
 
 float ensemble::Mean() const


### PR DESCRIPTION
Fractile plugin has so far been using sorted value list with removed missing values. Since there are use cases where missing values should be sorted to the end (or potentially beginning) of the distribution ensemble class member function SortedValues was modified do handle missing values accordingly.
Fractile plugin was modified to read additional key/value pair from plugin configuration.