### PR TITLE
raise lower threshold for low clouds

### DIFF
--- a/himan-scripts/cloudtype.lua
+++ b/himan-scripts/cloudtype.lua
@@ -169,7 +169,7 @@ for i=1, #t do
   --
 
   -- Cu: few/sct low clouds, and less than bkn middle clouds
-  if _cl > 0.0 and _cl <= 0.5 and _cm <= 0.5 then
+  if _cl > 0.01 and _cl <= 0.5 and _cm <= 0.5 then
     Cloud[i] = 156
     CloudInfoIncr("156")
   end


### PR DESCRIPTION
The script ended up filling all the clear skies with cloud type 156. This was due to setting threshold to >0 while the input files contained no zero values but slightly larger than 0. Discussion is in the ticket.