### PR TITLE
Add lua utilities

### DIFF
--- a/doc/plugin-luatool.md
+++ b/doc/plugin-luatool.md
@@ -745,7 +745,7 @@ Custom shape functions enable kernels like Gaussian:
 
 ```lua
 local sigma = 3  -- standard deviation in grid cells
-local gauss = create_mask(result:GetGrid():GetDi()/1000, 10, function(i, j, center, grid_radius)
+local gauss = utils.create_mask(result:GetGrid():GetDi()/1000, 10, function(i, j, center, grid_radius)
   local dx, dy = i - center, j - center
   return math.exp(-(dx*dx + dy*dy) / (2 * sigma * sigma))
 end, true)

--- a/doc/plugin-luatool.md
+++ b/doc/plugin-luatool.md
@@ -710,6 +710,47 @@ Parse a string to boolean.
 local value = ParseBoolean("true")
 ```
 
+# Utility scripts
+
+Utility scripts are shared Lua modules available to all scripts. They must be loaded explicitly with `require`.
+
+```lua
+local utils = require("utils")
+```
+
+| Function | Arguments | Return value | Description |
+|---|---|---|---|
+| round | number | number | Rounds n to the nearest integer |
+| create_mask | resolution_km, radius_km, shape, normalize | matrixf | Returns a mask as a matrixf to be used with filtering or local maximum or minimum. shape: "square", "circle", or a custom function(i, j, center, grid_radius) returning a weight. normalize: if true, weights are divided by their sum so the kernel sums to 1 |
+
+## Masking
+
+Use `normalize = true` with `Filter2D` for smoothing — weights sum to 1 so values stay in range:
+
+```lua
+-- Smooth a field over a 10 km radius; GetDi() returns metres so divide by 1000
+local avg_mask = utils.create_mask(result:GetGrid():GetDi()/1000, 10, "circle", true)
+local smoothed = Filter2D(datamat, avg_mask, configuration:GetUseCuda()):GetValues()
+```
+
+Use `normalize = false` with `Max2D`/`Min2D` for neighbourhood statistics — weights are just 1s acting as a mask:
+
+```lua
+-- Find the maximum value within a 50 km square neighbourhood
+local mask = utils.create_mask(result:GetGrid():GetDi()/1000, 50, "square", false)
+local neighbourhood_max = Max2D(datamat, mask, configuration:GetUseCuda()):GetValues()
+```
+
+Custom shape functions enable kernels like Gaussian:
+
+```lua
+local sigma = 3  -- standard deviation in grid cells
+local gauss = create_mask(result:GetGrid():GetDi()/1000, 10, function(i, j, center, grid_radius)
+  local dx, dy = i - center, j - center
+  return math.exp(-(dx*dx + dy*dy) / (2 * sigma * sigma))
+end, true)
+```
+
 # Examples
 
 To launch a lua script, we'll need the lua script itself and a himan configuration in json format.

--- a/himan-plugins/source/luatool.cpp
+++ b/himan-plugins/source/luatool.cpp
@@ -146,14 +146,6 @@ void luatool::InitLua()
 
 	luaL_openlibs(L);
 
-	lua_getglobal(L, "package");
-	lua_getfield(L, -1, "path");
-	std::string newPath = std::string(lua_tostring(L, -1)) + ";/usr/share/himan-scripts/?.lua";
-	lua_pop(L, 1);
-	lua_pushstring(L, newPath.c_str());
-	lua_setfield(L, -2, "path");
-	lua_pop(L, 1);
-
 	open(L);
 
 	set_pcall_callback(&BindErrorHandler);
@@ -200,6 +192,21 @@ void luatool::ResetVariables(std::shared_ptr<info<double>> myTargetInfo)
 	globals(L)["radon"] = r;
 }
 
+static void AddScriptDirToPath(lua_State* L, const std::string& scriptPath)
+{
+	std::string scriptDir = scriptPath.substr(0, scriptPath.find_last_of("/\\") + 1);
+
+	lua_getglobal(L, "package");
+	lua_getfield(L, -1, "path");
+	std::string currentPath = lua_tostring(L, -1);
+	lua_pop(L, 1);
+
+	std::string newPath = scriptDir + "?.lua;" + currentPath;
+	lua_pushstring(L, newPath.c_str());
+	lua_setfield(L, -2, "path");
+	lua_pop(L, 1);
+}
+
 bool luatool::ReadFile(const std::string& luaFile)
 {
 	if (!std::filesystem::exists(luaFile))
@@ -212,6 +219,7 @@ bool luatool::ReadFile(const std::string& luaFile)
 	{
 		timer t(true);
 		ASSERT(myL);
+		AddScriptDirToPath(myL, luaFile);
 		if (luaL_dofile(myL, luaFile.c_str()))
 		{
 			itsLogger.Error(lua_tostring(myL, -1));

--- a/himan-plugins/source/luatool.cpp
+++ b/himan-plugins/source/luatool.cpp
@@ -194,20 +194,29 @@ void luatool::ResetVariables(std::shared_ptr<info<double>> myTargetInfo)
 
 static void AddScriptDirToPath(lua_State* L, const std::string& scriptPath)
 {
-    std::string scriptDir = scriptPath.substr(0, scriptPath.find_last_of("/\\") + 1);
-    std::string entry = scriptDir + "?.lua";
+	const auto scriptDir = std::filesystem::path(scriptPath).parent_path();
+	const std::string entry = (scriptDir / "?.lua").string();
 
-    lua_getglobal(L, "package");
-    lua_getfield(L, -1, "path");
-    std::string currentPath = lua_tostring(L, -1);
-    lua_pop(L, 1);
+	lua_getglobal(L, "package");
+	if (!lua_istable(L, -1))
+	{
+		lua_pop(L, 1);
+		return;
+	}
 
-    if (currentPath.find(entry) == std::string::npos)
-    {
-        lua_pushstring(L, (entry + ";" + currentPath).c_str());
-        lua_setfield(L, -2, "path");
-    }
-    lua_pop(L, 1);
+	lua_getfield(L, -1, "path");
+	const char* pathCStr = lua_tostring(L, -1);
+	std::string currentPath = pathCStr ? pathCStr : "";
+	lua_pop(L, 1);
+
+	if (currentPath.find(entry) == std::string::npos)
+	{
+		const std::string newPath = currentPath.empty() ? entry : (entry + ";" + currentPath);
+		lua_pushlstring(L, newPath.data(), newPath.size());
+		lua_setfield(L, -2, "path");
+	}
+
+	lua_pop(L, 1);
 }
 
 bool luatool::ReadFile(const std::string& luaFile)

--- a/himan-plugins/source/luatool.cpp
+++ b/himan-plugins/source/luatool.cpp
@@ -146,6 +146,14 @@ void luatool::InitLua()
 
 	luaL_openlibs(L);
 
+	lua_getglobal(L, "package");
+	lua_getfield(L, -1, "path");
+	std::string newPath = std::string(lua_tostring(L, -1)) + ";/usr/share/himan-scripts/?.lua";
+	lua_pop(L, 1);
+	lua_pushstring(L, newPath.c_str());
+	lua_setfield(L, -2, "path");
+	lua_pop(L, 1);
+
 	open(L);
 
 	set_pcall_callback(&BindErrorHandler);

--- a/himan-plugins/source/luatool.cpp
+++ b/himan-plugins/source/luatool.cpp
@@ -194,17 +194,20 @@ void luatool::ResetVariables(std::shared_ptr<info<double>> myTargetInfo)
 
 static void AddScriptDirToPath(lua_State* L, const std::string& scriptPath)
 {
-	std::string scriptDir = scriptPath.substr(0, scriptPath.find_last_of("/\\") + 1);
+    std::string scriptDir = scriptPath.substr(0, scriptPath.find_last_of("/\\") + 1);
+    std::string entry = scriptDir + "?.lua";
 
-	lua_getglobal(L, "package");
-	lua_getfield(L, -1, "path");
-	std::string currentPath = lua_tostring(L, -1);
-	lua_pop(L, 1);
+    lua_getglobal(L, "package");
+    lua_getfield(L, -1, "path");
+    std::string currentPath = lua_tostring(L, -1);
+    lua_pop(L, 1);
 
-	std::string newPath = scriptDir + "?.lua;" + currentPath;
-	lua_pushstring(L, newPath.c_str());
-	lua_setfield(L, -2, "path");
-	lua_pop(L, 1);
+    if (currentPath.find(entry) == std::string::npos)
+    {
+        lua_pushstring(L, (entry + ";" + currentPath).c_str());
+        lua_setfield(L, -2, "path");
+    }
+    lua_pop(L, 1);
 }
 
 bool luatool::ReadFile(const std::string& luaFile)

--- a/himan-scripts/CB-TCU-base.lua
+++ b/himan-scripts/CB-TCU-base.lua
@@ -19,7 +19,7 @@ if not CBTCU_FL or not LCL500 or not LCLmu then
 end
 
 local Nmat = matrixf(result:GetGrid():GetNi(), result:GetGrid():GetNj(), 1, 0)
-local avg_filter = utils.create_filter(2.5, 10, "avg", "round")
+local avg_filter = utils.create_filter(result:GetGrid():GetDi()/1000, 10, "avg", "circle")
 
 Nmat:SetValues(LCL500)
 LCL500 = Filter2D(Nmat, avg_filter, configuration:GetUseCuda()):GetValues()

--- a/himan-scripts/CB-TCU-base.lua
+++ b/himan-scripts/CB-TCU-base.lua
@@ -1,7 +1,7 @@
 -- Cb or TCu cloud base (ft) and cover (%)
 -- Translated from https://wiki.fmi.fi/spaces/PROJEKTIT/pages/48558154/CbTCu_base_ft v1.2
 
-require("utils")
+local utils = require("utils")
 
 local MU = level(HPLevelType.kMaximumThetaE, 0)
 local HL = level(HPLevelType.kHeightLayer, 500, 0)
@@ -19,7 +19,7 @@ if not CBTCU_FL or not LCL500 or not LCLmu then
 end
 
 local Nmat = matrixf(result:GetGrid():GetNi(), result:GetGrid():GetNj(), 1, 0)
-local avg_filter = create_filter(2.5, 10, "avg", "round")
+local avg_filter = utils.create_filter(2.5, 10, "avg", "round")
 
 Nmat:SetValues(LCL500)
 LCL500 = Filter2D(Nmat, avg_filter, configuration:GetUseCuda()):GetValues()
@@ -60,8 +60,8 @@ for i = 1, #CBTCU_FL do
     cover = ProbCb[i]
   end
 
-  base_res[i] = round(safe_base_heights[i] / 0.3048 / 100) * 100  -- metres → feet, 100 ft resolution
-  cov_res[i]  = round(cover)
+  base_res[i] = utils.round(safe_base_heights[i] / 0.3048 / 100) * 100  -- metres → feet, 100 ft resolution
+  cov_res[i]  = utils.round(cover)
 end
 
 result:SetParam(param("CBTCU-FT"))

--- a/himan-scripts/CB-TCU-base.lua
+++ b/himan-scripts/CB-TCU-base.lua
@@ -19,13 +19,13 @@ if not CBTCU_FL or not LCL500 or not LCLmu then
 end
 
 local Nmat = matrixf(result:GetGrid():GetNi(), result:GetGrid():GetNj(), 1, 0)
-local avg_filter = utils.create_filter(result:GetGrid():GetDi()/1000, 10, "avg", "circle")
+local avg_mask = utils.create_mask(result:GetGrid():GetDi()/1000, 10, "circle", true)
 
 Nmat:SetValues(LCL500)
-LCL500 = Filter2D(Nmat, avg_filter, configuration:GetUseCuda()):GetValues()
+LCL500 = Filter2D(Nmat, avg_mask, configuration:GetUseCuda()):GetValues()
 
 Nmat:SetValues(LCLmu)
-LCLmu = Filter2D(Nmat, avg_filter, configuration:GetUseCuda()):GetValues()
+LCLmu = Filter2D(Nmat, avg_mask, configuration:GetUseCuda()):GetValues()
 
 -- Build per-grid-point base heights for vertical N lookup.
 local safe_base_heights = {}

--- a/himan-scripts/CB-TCU-base.lua
+++ b/himan-scripts/CB-TCU-base.lua
@@ -1,9 +1,7 @@
 -- Cb or TCu cloud base (ft) and cover (%)
 -- Translated from https://wiki.fmi.fi/spaces/PROJEKTIT/pages/48558154/CbTCu_base_ft v1.2
 
-function round(n)
-  return n % 1 >= 0.5 and math.ceil(n) or math.floor(n)
-end
+require("utils")
 
 local MU = level(HPLevelType.kMaximumThetaE, 0)
 local HL = level(HPLevelType.kHeightLayer, 500, 0)
@@ -20,27 +18,8 @@ if not CBTCU_FL or not LCL500 or not LCLmu then
   return
 end
 
--- Spatial averaging of LCL within ~10 km radius using circular 9x9 kernel
--- (MEPS ~2.5 km resolution → radius ~4 grid cells ≈ 10 km)
-local kernel = {0,0,0,0,1,0,0,0,0,
-                0,0,1,1,1,1,1,0,0,
-                0,1,1,1,1,1,1,1,0,
-                0,1,1,1,1,1,1,1,0,
-                1,1,1,1,1,1,1,1,1,
-                0,1,1,1,1,1,1,1,0,
-                0,1,1,1,1,1,1,1,0,
-                0,0,1,1,1,1,1,0,0,
-                0,0,0,0,1,0,0,0,0}
-
-local avgkernel = {}
-for i = 1, #kernel do
-  avgkernel[i] = kernel[i] / 49
-end
-
-local avg_filter = matrixf(9, 9, 1, missing)
-avg_filter:SetValues(avgkernel)
-
 local Nmat = matrixf(result:GetGrid():GetNi(), result:GetGrid():GetNj(), 1, 0)
+local avg_filter = create_filter(2.5, 10, "avg", "round")
 
 Nmat:SetValues(LCL500)
 LCL500 = Filter2D(Nmat, avg_filter, configuration:GetUseCuda()):GetValues()

--- a/himan-scripts/utils.lua
+++ b/himan-scripts/utils.lua
@@ -8,40 +8,52 @@ end
 -- resolution_km: grid resolution in km
 -- radius_km: smoothing radius in km
 -- style: "uniform" for mask of 1s, "avg" for averaging (1/count per active cell)
--- shape: "square" or "round"
+-- shape: "square" or "circle"
 function U.create_filter(resolution_km, radius_km, style, shape)
-  if shape ~= "square" and shape ~= "round" then
+  local shape_weights = {
+    square = function(i, j, center, grid_radius) return 1 end,
+    circle = function(i, j, center, grid_radius)
+      return math.sqrt((i - center)^2 + (j - center)^2) <= grid_radius and 1 or 0
+    end,
+  }
+
+  if not shape_weights[shape] then
     logger:Error("Invalid shape given to create_filter")
     return
   end
-  
+
   if style ~= "uniform" and style ~= "avg" then
     logger:Error("Invalid style given to create_filter")
     return
   end
-  
+
+  if type(resolution_km) ~= "number" or resolution_km <= 0 then
+    logger:Error("resolution_km must be a positive number")
+    return
+  end
+
+  if type(radius_km) ~= "number" or radius_km <= 0 then
+    logger:Error("radius_km must be a positive number")
+    return
+  end
+
   local grid_radius = math.floor(radius_km / resolution_km)
   local size = 2 * grid_radius + 1
   local center = grid_radius
   local kernel = {}
-  local count = 0
+  local weight_sum = 0
 
   for i = 0, size - 1 do
     for j = 0, size - 1 do
-      if shape == "square" or math.sqrt((i - center)^2 + (j - center)^2) <= grid_radius then
-        kernel[i * size + j + 1] = 1
-        count = count + 1
-      else
-        kernel[i * size + j + 1] = 0
-      end
+      local w = shape_weights[shape](i, j, center, grid_radius)
+      kernel[i * size + j + 1] = w
+      weight_sum = weight_sum + w
     end
   end
 
   if style == "avg" then
     for i = 1, #kernel do
-      if kernel[i] ~= 0 then
-        kernel[i] = kernel[i] / count
-      end
+      kernel[i] = kernel[i] / weight_sum
     end
   end
 

--- a/himan-scripts/utils.lua
+++ b/himan-scripts/utils.lua
@@ -7,23 +7,28 @@ end
 -- Returns a filter kernel as a matrixf.
 -- resolution_km: grid resolution in km
 -- radius_km: smoothing radius in km
--- style: "uniform" for mask of 1s, "avg" for averaging (1/count per active cell)
--- shape: "square" or "circle"
-function U.create_filter(resolution_km, radius_km, style, shape)
-  local shape_weights = {
-    square = function(i, j, center, grid_radius) return 1 end,
+-- normalize: if true, weights are divided by their sum so the kernel sums to 1
+-- shape: "square", "circle", or a function(i, j, center, grid_radius) returning a weight
+function U.create_mask(resolution_km, radius_km, shape, normalize)
+  local builtins = {
+    square = function() return 1 end,
     circle = function(i, j, center, grid_radius)
       return math.sqrt((i - center)^2 + (j - center)^2) <= grid_radius and 1 or 0
     end,
   }
 
-  if not shape_weights[shape] then
-    logger:Error("Invalid shape given to create_filter")
+  local weight_fn
+  if type(shape) == "function" then
+    weight_fn = shape
+  elseif builtins[shape] then
+    weight_fn = builtins[shape]
+  else
+    logger:Error("Invalid shape given to create_mask")
     return
   end
 
-  if style ~= "uniform" and style ~= "avg" then
-    logger:Error("Invalid style given to create_filter")
+  if type(normalize) ~= "boolean" then
+    logger:Error("normalize must be a boolean")
     return
   end
 
@@ -45,13 +50,13 @@ function U.create_filter(resolution_km, radius_km, style, shape)
 
   for i = 0, size - 1 do
     for j = 0, size - 1 do
-      local w = shape_weights[shape](i, j, center, grid_radius)
+      local w = weight_fn(i, j, center, grid_radius)
       kernel[i * size + j + 1] = w
       weight_sum = weight_sum + w
     end
   end
 
-  if style == "avg" then
+  if normalize then
     for i = 1, #kernel do
       kernel[i] = kernel[i] / weight_sum
     end

--- a/himan-scripts/utils.lua
+++ b/himan-scripts/utils.lua
@@ -17,7 +17,8 @@ function U.create_mask(resolution_km, radius_km, shape, normalize)
   local builtins = {
     square = function() return 1 end,
     circle = function(i, j, center, grid_radius)
-      return math.sqrt((i - center)^2 + (j - center)^2) <= grid_radius and 1 or 0
+      local dx, dy = i - center, j - center
+      return (dx * dx + dy * dy) <= (grid_radius * grid_radius) and 1 or 0
     end,
   }
 

--- a/himan-scripts/utils.lua
+++ b/himan-scripts/utils.lua
@@ -1,7 +1,11 @@
 local U = {}
 
 function U.round(n)
-  return n % 1 >= 0.5 and math.ceil(n) or math.floor(n)
+  if n >= 0 then
+    return math.floor(n + 0.5)
+  else
+    return math.ceil(n - 0.5)
+  end
 end
 
 -- Returns a filter kernel as a matrixf.

--- a/himan-scripts/utils.lua
+++ b/himan-scripts/utils.lua
@@ -1,4 +1,6 @@
-function round(n)
+local U = {}
+
+function U.round(n)
   return n % 1 >= 0.5 and math.ceil(n) or math.floor(n)
 end
 
@@ -7,7 +9,7 @@ end
 -- radius_km: smoothing radius in km
 -- style: "uniform" for mask of 1s, "avg" for averaging (1/count per active cell)
 -- shape: "square" or "round"
-function create_filter(resolution_km, radius_km, style, shape)
+function U.create_filter(resolution_km, radius_km, style, shape)
   if shape ~= "square" and shape ~= "round" then
     logger:Error("Invalid shape given to create_filter")
     return
@@ -47,3 +49,5 @@ function create_filter(resolution_km, radius_km, style, shape)
   f:SetValues(kernel)
   return f
 end
+
+return U

--- a/himan-scripts/utils.lua
+++ b/himan-scripts/utils.lua
@@ -1,0 +1,49 @@
+function round(n)
+  return n % 1 >= 0.5 and math.ceil(n) or math.floor(n)
+end
+
+-- Returns a filter kernel as a matrixf.
+-- resolution_km: grid resolution in km
+-- radius_km: smoothing radius in km
+-- style: "uniform" for mask of 1s, "avg" for averaging (1/count per active cell)
+-- shape: "square" or "round"
+function create_filter(resolution_km, radius_km, style, shape)
+  if shape ~= "square" and shape ~= "round" then
+    logger:Error("Invalid shape given to create_filter")
+    return
+  end
+  
+  if style ~= "uniform" and style ~= "avg" then
+    logger:Error("Invalid style given to create_filter")
+    return
+  end
+  
+  local grid_radius = math.floor(radius_km / resolution_km)
+  local size = 2 * grid_radius + 1
+  local center = grid_radius
+  local kernel = {}
+  local count = 0
+
+  for i = 0, size - 1 do
+    for j = 0, size - 1 do
+      if shape == "square" or math.sqrt((i - center)^2 + (j - center)^2) <= grid_radius then
+        kernel[i * size + j + 1] = 1
+        count = count + 1
+      else
+        kernel[i * size + j + 1] = 0
+      end
+    end
+  end
+
+  if style == "avg" then
+    for i = 1, #kernel do
+      if kernel[i] ~= 0 then
+        kernel[i] = kernel[i] / count
+      end
+    end
+  end
+
+  local f = matrixf(size, size, 1, missing)
+  f:SetValues(kernel)
+  return f
+end

--- a/himan-scripts/utils.lua
+++ b/himan-scripts/utils.lua
@@ -61,6 +61,10 @@ function U.create_mask(resolution_km, radius_km, shape, normalize)
   end
 
   if normalize then
+    if weight_sum == 0 then
+      logger:Error("create_mask produced zero-sum kernel; cannot normalize")
+      return
+    end
     for i = 1, #kernel do
       kernel[i] = kernel[i] / weight_sum
     end


### PR DESCRIPTION
This pull request introduces a new utility module (`utils.lua`) to centralize common Lua functions and refactors `CB-TCU-base.lua` to use these utilities. It also improves how Lua scripts are loaded by ensuring their directory is added to the Lua module search path in the C++ code.

**Lua utility module and code refactoring:**

* Added a new `utils.lua` module providing a `round` function and a flexible `create_filter` function for generating filter kernels, improving code reuse and maintainability.
* Refactored `CB-TCU-base.lua` to use `utils.round` and `utils.create_filter` instead of local implementations, simplifying the script and making filter creation more flexible. [[1]](diffhunk://#diff-eeb62526ee211aef5f0cd586e44d6576f38ba27dd1bf0b114b158914ac10d4fdL4-R4) [[2]](diffhunk://#diff-eeb62526ee211aef5f0cd586e44d6576f38ba27dd1bf0b114b158914ac10d4fdL23-R22) [[3]](diffhunk://#diff-eeb62526ee211aef5f0cd586e44d6576f38ba27dd1bf0b114b158914ac10d4fdL84-R64)

**Lua script loading improvements:**

* Added the `AddScriptDirToPath` function in `luatool.cpp` to ensure the directory of the loaded Lua script is included in the Lua `package.path`, allowing scripts to require local modules like `utils.lua` without manual path management. [[1]](diffhunk://#diff-b71c68da189f2782ba0a56825ec9ca8ee570e4f9fbc1da0e21103fa1f8acdf84R195-R212) [[2]](diffhunk://#diff-b71c68da189f2782ba0a56825ec9ca8ee570e4f9fbc1da0e21103fa1f8acdf84R225)
