### PR TITLE
Add script for freezing levels

### DIFF
--- a/himan-scripts/freezing-levels.lua
+++ b/himan-scripts/freezing-levels.lua
@@ -1,0 +1,29 @@
+-- Compute first, second and last freezing levels
+-- Used in ILME 
+
+local utils = require("utils")
+
+local t_param = param("T-K")
+local fzT = 273.15
+
+local first  = hitool:VerticalHeight(t_param, 0, 15000, fzT, 1)
+local second = hitool:VerticalHeight(t_param, 0, 15000, fzT, 2)
+local last   = hitool:VerticalHeight(t_param, 0, 15000, fzT, 0)
+
+for i = 1, #first do
+  first[i]  = utils.round(first[i]  / 0.3048)
+  second[i] = utils.round(second[i] / 0.3048)
+  last[i]   = utils.round(last[i]   / 0.3048)
+end
+
+result:SetParam(param("H0C-1ST-FT"))
+result:SetValues(first)
+luatool:WriteToFile(result)
+
+result:SetParam(param("H0C-2ND-FT"))
+result:SetValues(second)
+luatool:WriteToFile(result)
+
+result:SetParam(param("H0C-HIGHEST-FT"))
+result:SetValues(last)
+luatool:WriteToFile(result)


### PR DESCRIPTION
This pull request introduces a new Lua script, `himan-scripts/freezing-levels.lua`, to compute and output the first, second, and highest freezing levels in feet.

https://jira.fmi.fi/browse/STU-32944
https://jira.fmi.fi/browse/STU-32945
https://jira.fmi.fi/browse/STU-32946

**New freezing level calculations:**

* Added computation of first, second, and highest freezing levels using the `hitool:VerticalHeight` function with temperature parameter `T-K` and a freezing threshold of 273.15K.
* Converted the computed heights from meters to feet and rounded the results using the `utils.round` function.

**Output and integration:**

* Wrote each freezing level to the result object with parameter names `H0C-1ST-FT`, `H0C-2ND-FT`, and `H0C-HIGHEST-FT`, and saved them using `luatool:WriteToFile`.