### PR TITLE
Add severe icing script

### DIFF
--- a/himan-scripts/icing-base-top.lua
+++ b/himan-scripts/icing-base-top.lua
@@ -7,54 +7,51 @@ Produce it in both flight level and hft coordinates
 ]]
 
 logger:Info("Calculating base and top for icing")
-local utils = require("utils")
 local MISS = missing
 local IceParam = param("ICING-N")
 
--- We set the vertical search function to work with pressure based vertical coordinate
--- The reasoning is that the pressures can be directly converted into flight levels (FL)
-hitool:SetHeightUnit(HPParameterUnit.kHPa)
+-- The vertical search is done in the default height based coordinate (HL-M),
+-- so the search range and the ground level limit are given in meters
+
+-- Highest searched height
+local maxH = 10000
 
 -- Get surface pressure
 local p = luatool:Fetch(current_time, level(HPLevelType.kHeight, 0), param("P-PA"), current_forecast_type)
 
-function BaseHPa(threshold)
-  -- Find the base of icing define as the lowest height / highest pressure at which icing index crosses the threshold value
-  -- returns the height as pressure based coordinate
+function BaseHeight(threshold)
+  -- Find the base of icing define as the lowest height at which icing index crosses the threshold value
+  -- returns the height in meters
 
   local zerodata = {}
-  local pFL300data = {}
+  local maxHdata = {}
   local thresholddata = {}
 
   for i = 1, #p do
-     -- convert surface pressure to hPa
-     zerodata[i] = p[i] / 100
+     zerodata[i] = 0
      thresholddata[i] = threshold
-
-     -- FL300 (30000ft=301hPa)
-     pFL300data[i] = 301
+     maxHdata[i] = maxH
   end
 
-  local basedata = hitool:VerticalHeightGreaterThanGrid(IceParam, zerodata, pFL300data, thresholddata, 1)
+  local basedata = hitool:VerticalHeightGreaterThanGrid(IceParam, zerodata, maxHdata, thresholddata, 1)
 
   return basedata
 end
 
-function TopHPa(threshold,basedata)
-  -- Find the next top above the base of icing define as the height / pressure at which icing index crosses the threshold value
-  -- returns the height as pressure
+function TopHeight(threshold,basedata)
+  -- Find the next top above the base of icing define as the height at which icing index crosses the threshold value
+  -- returns the height in meters
 
-  local pFL300data = {}
+  local maxHdata = {}
   local thresholddata = {}
 
   for i = 1, #basedata do
      thresholddata[i] = threshold
-
-     -- FL300 (30000ft=301hPa)
-     pFL300data[i] = 301
+     maxHdata[i] = maxH
   end
 
-  local topdata = hitool:VerticalHeightLessThanGrid(IceParam, basedata, pFL300data, thresholddata, 1)
+  -- Search is started slightly above the base, otherwise the base itself is returned as the top
+  local topdata = hitool:VerticalHeightLessThanGrid(IceParam, AddScalar(basedata,1), maxHdata, thresholddata, 1)
 
   return topdata
 end
@@ -71,27 +68,41 @@ end
 -- the value 4, so that the layer is not padded towards the neighbouring model levels.
 -- The base threshold is nudged just below 4 because the search is done with a strict
 -- comparison (>).
-local baseHPa = BaseHPa(3.999) -- icing index >=4
-local topHPa = TopHPa(4,AddScalar(baseHPa,-1)) -- icing index <4
+local baseM = BaseHeight(4 - 0.001) -- icing index >= 4
+local topM = TopHeight(4,baseM) -- icing index < 4
 
--- Convert top [hPa] to FL
-local topFL = {}
-local baseFL = {}
-for i=1, #topHPa do
-  topFL[i] = FlightLevel_(topHPa[i] * 100)
-  baseFL[i] = FlightLevel_(baseHPa[i] * 100)
+-- Base and top are always given as a pair
+for i=1, #baseM do
+  if IsMissing(baseM[i]) then
+    topM[i] = MISS
+  elseif IsMissing(topM[i]) then
+    -- Icing continues above the searched range
+    topM[i] = maxH
+  end
 end
 
--- Fetch metric heights of base and top to convert them to hFt
-local baseM = hitool:VerticalValueGrid(param("HL-M"), baseHPa)
-local topM = hitool:VerticalValueGrid(param("HL-M"), topHPa)
+-- Fetch pressures [hPa] of base and top to convert them to FL
+local baseP = hitool:VerticalValueGrid(param("P-HPA"), baseM)
+local topP = hitool:VerticalValueGrid(param("P-HPA"), topM)
 
--- Convert top [M] to hFt
+-- Convert base and top to FL and hFt
+local topFL = {}
+local baseFL = {}
 local topHFt = {}
 local baseHFt = {}
 for i=1, #baseM do
-  topHFt[i] = utils.round(topM[i] / 0.3048 / 100)
-  baseHFt[i] = utils.round(baseM[i] / 0.3048 / 100)
+  -- Top is rounded up and base down so that the rounding does not narrow the layer
+  topFL[i] = FlightLevel_(topP[i] * 100) -- hPa to Pa
+  topHFt[i] = math.ceil(topM[i] / 30.48) -- 0.3048 / 100
+
+  -- If height < 15 m, icing reaches the ground (0 m)
+  if baseM[i] < 15 then
+    baseFL[i] = 0
+    baseHFt[i] = 0
+  else
+    baseFL[i] = FlightLevel_(baseP[i] * 100) -- hPa to Pa
+    baseHFt[i] = math.floor(baseM[i] / 30.48) -- 0.3048 / 100
+  end
 end
 
 result:SetParam(param("ICING-TOP-FL"))

--- a/himan-scripts/icing-base-top.lua
+++ b/himan-scripts/icing-base-top.lua
@@ -10,48 +10,51 @@ logger:Info("Calculating base and top for icing")
 local MISS = missing
 local IceParam = param("ICING-N")
 
--- The vertical search is done in the default height based coordinate (HL-M),
--- so the search range and the ground level limit are given in meters
+-- We set the vertical search function to work with pressure based vertical coordinate
+-- The reasoning is that the search limits are better defined in the pressure domain and
+-- the pressures can be directly converted into flight levels (FL)
+hitool:SetHeightUnit(HPParameterUnit.kHPa)
 
--- Highest searched height
-local maxH = 10000
+-- Highest searched height, 10000 m in the standard atmosphere
+local maxP = 264
 
 -- Get surface pressure
 local p = luatool:Fetch(current_time, level(HPLevelType.kHeight, 0), param("P-PA"), current_forecast_type)
 
-function BaseHeight(threshold)
-  -- Find the base of icing define as the lowest height at which icing index crosses the threshold value
-  -- returns the height in meters
+function BaseHPa(threshold)
+  -- Find the base of icing define as the lowest height / highest pressure at which icing index crosses the threshold value
+  -- returns the height as pressure based coordinate
 
   local zerodata = {}
-  local maxHdata = {}
+  local maxPdata = {}
   local thresholddata = {}
 
   for i = 1, #p do
-     zerodata[i] = 0
+     -- convert surface pressure to hPa
+     zerodata[i] = p[i] / 100
      thresholddata[i] = threshold
-     maxHdata[i] = maxH
+     maxPdata[i] = maxP
   end
 
-  local basedata = hitool:VerticalHeightGreaterThanGrid(IceParam, zerodata, maxHdata, thresholddata, 1)
+  local basedata = hitool:VerticalHeightGreaterThanGrid(IceParam, zerodata, maxPdata, thresholddata, 1)
 
   return basedata
 end
 
-function TopHeight(threshold,basedata)
-  -- Find the next top above the base of icing define as the height at which icing index crosses the threshold value
-  -- returns the height in meters
+function TopHPa(threshold,basedata)
+  -- Find the next top above the base of icing define as the height / pressure at which icing index crosses the threshold value
+  -- returns the height as pressure
 
-  local maxHdata = {}
+  local maxPdata = {}
   local thresholddata = {}
 
   for i = 1, #basedata do
      thresholddata[i] = threshold
-     maxHdata[i] = maxH
+     maxPdata[i] = maxP
   end
 
   -- Search is started slightly above the base, otherwise the base itself is returned as the top
-  local topdata = hitool:VerticalHeightLessThanGrid(IceParam, AddScalar(basedata,1), maxHdata, thresholddata, 1)
+  local topdata = hitool:VerticalHeightLessThanGrid(IceParam, AddScalar(basedata,-1), maxPdata, thresholddata, 1)
 
   return topdata
 end
@@ -68,42 +71,42 @@ end
 -- the value 4, so that the layer is not padded towards the neighbouring model levels.
 -- The base threshold is nudged just below 4 because the search is done with a strict
 -- comparison (>).
-local baseM = BaseHeight(4 - 0.001) -- icing index >= 4
-local topM = TopHeight(4,baseM) -- icing index < 4
+local baseHPa = BaseHPa(4 - 0.001) -- icing index >= 4
+local topHPa = TopHPa(4,baseHPa) -- icing index < 4
 
 -- Base and top are always given as a pair
-for i=1, #baseM do
-  if IsMissing(baseM[i]) then
-    topM[i] = MISS
-  elseif IsMissing(topM[i]) then
+for i=1, #baseHPa do
+  if IsMissing(baseHPa[i]) then
+    topHPa[i] = MISS
+  elseif IsMissing(topHPa[i]) then
     -- Icing continues above the searched range
-    topM[i] = maxH
+    topHPa[i] = maxP
   end
 end
 
--- Fetch pressures [hPa] of base and top to convert them to FL
-local baseP = hitool:VerticalValueGrid(param("P-HPA"), baseM)
-local topP = hitool:VerticalValueGrid(param("P-HPA"), topM)
+-- Fetch metric heights of base and top to convert them to hFt
+local baseM = hitool:VerticalValueGrid(param("HL-M"), baseHPa)
+local topM = hitool:VerticalValueGrid(param("HL-M"), topHPa)
 
 -- Convert base and top to FL and hFt
 local topFL = {}
 local baseFL = {}
 local topHFt = {}
 local baseHFt = {}
-for i=1, #baseM do
-  -- Top is rounded up and base down so that the rounding does not narrow the layer
-  topFL[i] = FlightLevel_(topP[i] * 100) -- hPa to Pa
+for i=1, #baseHPa do
+  topFL[i] = FlightLevel_(topHPa[i] * 100) -- hPa to Pa
   topHFt[i] = math.ceil(topM[i] / 30.48) -- 0.3048 / 100
 
   -- If height < 15 m, icing reaches the ground (0 m)
   if baseM[i] < 15 then
-    baseFL[i] = 0
+    baseFL[i] = FlightLevel_(p[i])
     baseHFt[i] = 0
   else
-    baseFL[i] = FlightLevel_(baseP[i] * 100) -- hPa to Pa
+    baseFL[i] = FlightLevel_(baseHPa[i] * 100) -- hPa to Pa
     baseHFt[i] = math.floor(baseM[i] / 30.48) -- 0.3048 / 100
   end
 end
+
 
 result:SetParam(param("ICING-TOP-FL"))
 result:SetValues(topFL)
@@ -128,4 +131,3 @@ result:SetValues(baseHFt)
 
 logger:Info("Writing source data to file")
 luatool:WriteToFile(result)
-

--- a/himan-scripts/icing-base-top.lua
+++ b/himan-scripts/icing-base-top.lua
@@ -67,7 +67,11 @@ function AddScalar(arr, scalar)
   return ret
 end
 
-local baseHPa = BaseHPa(3) -- icing index >=4
+-- Base and top are the heights where the interpolated icing index reaches and leaves
+-- the value 4, so that the layer is not padded towards the neighbouring model levels.
+-- The base threshold is nudged just below 4 because the search is done with a strict
+-- comparison (>).
+local baseHPa = BaseHPa(3.999) -- icing index >=4
 local topHPa = TopHPa(4,AddScalar(baseHPa,-1)) -- icing index <4
 
 -- Convert top [hPa] to FL

--- a/himan-scripts/icing-severe-base-top.lua
+++ b/himan-scripts/icing-severe-base-top.lua
@@ -1,0 +1,123 @@
+--[[
+ 
+Severe icing computation for ILME 
+
+Find the base and top of severe icing index defined by some threshold
+Produce it in both flight level and hft coordinates
+]]
+
+logger:Info("Calculating base and top for severe icing")
+local utils = require("utils")
+
+local IceParam = param("ICING-N")
+
+-- We set the vertical search function to work with pressure based vertical coordinate
+-- The reasoning is that the pressures can be directly converted into flight levels (FL)
+hitool:SetHeightUnit(HPParameterUnit.kHPa)
+
+-- Get surface pressure
+local p = luatool:Fetch(current_time, level(HPLevelType.kHeight, 0), param("P-PA"), current_forecast_type)
+
+function BaseHPa(threshold)
+  -- Find the base of icing define as the lowest height / highest pressure at which icing index crosses the threshold value
+  -- returns the height as pressure based coordinate
+
+  local zerodata = {}
+  local pFL300data = {}
+  local thresholddata = {}
+
+  for i = 1, #p do
+     -- convert surface pressure to hPa
+     zerodata[i] = p[i] / 100
+     thresholddata[i] = threshold
+
+     -- FL300 (30000ft=301hPa)
+     pFL300data[i] = 301
+  end
+
+  local basedata = hitool:VerticalHeightGreaterThanGrid(IceParam, zerodata, pFL300data, thresholddata, 1)
+
+  return basedata
+end
+
+function TopHPa(threshold,basedata)
+  -- Find the next top above the base of icing define as the height / pressure at which icing index crosses the threshold value
+  -- returns the height as pressure
+
+  local pFL300data = {}
+  local thresholddata = {}
+
+  for i = 1, #basedata do
+     thresholddata[i] = threshold
+
+     -- FL300 (30000ft=301hPa)
+     pFL300data[i] = 301
+  end
+
+  local topdata = hitool:VerticalHeightLessThanGrid(IceParam, basedata, pFL300data, thresholddata, 1)
+
+  return topdata
+end
+
+function AddScalar(arr, scalar)
+  local ret = {}
+  for i=1,#arr do
+    ret[i] = arr[i] + scalar
+  end
+  return ret
+end
+
+local baseHPa = BaseHPa(6) -- severe icing index >= 7
+local topHPa = TopHPa(7,AddScalar(baseHPa,-1)) -- severe icing index < 7
+
+-- Convert pressure to FL
+local topFL = {}
+local baseFL = {}
+for i=1, #topHPa do
+  topFL[i] = FlightLevel_(topHPa[i] * 100)
+  baseFL[i] = FlightLevel_(baseHPa[i] * 100)
+end
+
+-- Fetch metric heights of base and top to convert them to hFt
+local baseM = hitool:VerticalValueGrid(param("HL-M"), baseHPa)
+local topM = hitool:VerticalValueGrid(param("HL-M"), topHPa)
+
+-- Convert top [M] to hFt
+local topHFt = {}
+local baseHFt = {}
+for i=1, #baseM do
+  -- If height < 15 m, icing should be classified as freezing rain/drizzle (0 m)
+  if baseM[i] < 15 then
+    topHFt[i] = 0
+    baseHFt[i] = 0
+  else
+    topHFt[i] = utils.round(topM[i] / 0.3048 / 100)
+    baseHFt[i] = utils.round(baseM[i] / 0.3048 / 100)
+  end
+end
+
+
+result:SetParam(param("ICING-SEV-TOP-FL"))
+result:SetValues(topFL)
+
+logger:Info("Writing source data to file")
+luatool:WriteToFile(result)
+
+result:SetParam(param("ICING-SEV-BASE-FL"))
+result:SetValues(baseFL)
+
+logger:Info("Writing source data to file")
+luatool:WriteToFile(result)
+
+result:SetParam(param("ICING-SEV-TOP-FT"))
+result:SetValues(topHFt)
+
+logger:Info("Writing source data to file")
+luatool:WriteToFile(result)
+
+result:SetParam(param("ICING-SEV-BASE-FT"))
+result:SetValues(baseHFt)
+
+logger:Info("Writing source data to file")
+luatool:WriteToFile(result)
+

--- a/himan-scripts/icing-severe-base-top.lua
+++ b/himan-scripts/icing-severe-base-top.lua
@@ -10,48 +10,51 @@ logger:Info("Calculating base and top for severe icing")
 
 local IceParam = param("ICING-N")
 
--- The vertical search is done in the default height based coordinate (HL-M),
--- so the search range and the freezing rain/drizzle limit are given in meters
+-- We set the vertical search function to work with pressure based vertical coordinate
+-- The reasoning is that the search limits are better defined in the pressure domain and
+-- the pressures can be directly converted into flight levels (FL)
+hitool:SetHeightUnit(HPParameterUnit.kHPa)
 
--- Highest searched height
-local maxH = 10000
+-- Highest searched height, 10000 m in the standard atmosphere
+local maxP = 264
 
 -- Get surface pressure
 local p = luatool:Fetch(current_time, level(HPLevelType.kHeight, 0), param("P-PA"), current_forecast_type)
 
-function BaseHeight(threshold)
-  -- Find the base of icing define as the lowest height at which icing index crosses the threshold value
-  -- returns the height in meters
+function BaseHPa(threshold)
+  -- Find the base of icing define as the lowest height / highest pressure at which icing index crosses the threshold value
+  -- returns the height as pressure based coordinate
 
   local zerodata = {}
-  local maxHdata = {}
+  local maxPdata = {}
   local thresholddata = {}
 
   for i = 1, #p do
-     zerodata[i] = 0
+     -- convert surface pressure to hPa
+     zerodata[i] = p[i] / 100
      thresholddata[i] = threshold
-     maxHdata[i] = maxH
+     maxPdata[i] = maxP
   end
 
-  local basedata = hitool:VerticalHeightGreaterThanGrid(IceParam, zerodata, maxHdata, thresholddata, 1)
+  local basedata = hitool:VerticalHeightGreaterThanGrid(IceParam, zerodata, maxPdata, thresholddata, 1)
 
   return basedata
 end
 
-function TopHeight(threshold,basedata)
-  -- Find the next top above the base of icing define as the height at which icing index crosses the threshold value
-  -- returns the height in meters
+function TopHPa(threshold,basedata)
+  -- Find the next top above the base of icing define as the height / pressure at which icing index crosses the threshold value
+  -- returns the height as pressure
 
-  local maxHdata = {}
+  local maxPdata = {}
   local thresholddata = {}
 
   for i = 1, #basedata do
      thresholddata[i] = threshold
-     maxHdata[i] = maxH
+     maxPdata[i] = maxP
   end
 
   -- Search is started slightly above the base, otherwise the base itself is returned as the top
-  local topdata = hitool:VerticalHeightLessThanGrid(IceParam, AddScalar(basedata,1), maxHdata, thresholddata, 1)
+  local topdata = hitool:VerticalHeightLessThanGrid(IceParam, AddScalar(basedata,-1), maxPdata, thresholddata, 1)
 
   return topdata
 end
@@ -68,30 +71,30 @@ end
 -- the value 7, so that the layer is not padded towards the neighbouring model levels.
 -- The base threshold is nudged just below 7 because the search is done with a strict
 -- comparison (>).
-local baseM = BaseHeight(7 - 0.001) -- severe icing index >= 7
-local topM = TopHeight(7,baseM) -- severe icing index < 7
+local baseHPa = BaseHPa(7 - 0.001) -- severe icing index >= 7
+local topHPa = TopHPa(7,baseHPa) -- severe icing index < 7
 
 -- Base and top are always given as a pair
-for i=1, #baseM do
-  if IsMissing(baseM[i]) then
-    topM[i] = missing
-  elseif IsMissing(topM[i]) then
+for i=1, #baseHPa do
+  if IsMissing(baseHPa[i]) then
+    topHPa[i] = missing
+  elseif IsMissing(topHPa[i]) then
     -- Icing continues above the searched range
-    topM[i] = maxH
+    topHPa[i] = maxP
   end
 end
 
--- Fetch pressures of base and top to convert them to FL
-local baseP = hitool:VerticalValueGrid(param("P-HPA"), baseM)
-local topP = hitool:VerticalValueGrid(param("P-HPA"), topM)
+-- Fetch metric heights of base and top to convert them to hFt
+local baseM = hitool:VerticalValueGrid(param("HL-M"), baseHPa)
+local topM = hitool:VerticalValueGrid(param("HL-M"), topHPa)
 
 -- Convert base and top to FL and hFt
 local topFL = {}
 local baseFL = {}
 local topHFt = {}
 local baseHFt = {}
-for i=1, #baseM do
-  topFL[i] = FlightLevel_(topP[i] * 100) -- hPa to Pa
+for i=1, #baseHPa do
+  topFL[i] = FlightLevel_(topHPa[i] * 100) -- hPa to Pa
   topHFt[i] = math.ceil(topM[i] / 30.48) -- 0.3048 / 100
 
   -- If height < 15 m, icing should be classified as freezing rain/drizzle (0 m)
@@ -99,7 +102,7 @@ for i=1, #baseM do
     baseFL[i] = FlightLevel_(p[i])
     baseHFt[i] = 0
   else
-    baseFL[i] = FlightLevel_(baseP[i] * 100) -- hPa to Pa
+    baseFL[i] = FlightLevel_(baseHPa[i] * 100) -- hPa to Pa
     baseHFt[i] = math.floor(baseM[i] / 30.48) -- 0.3048 / 100
   end
 end
@@ -128,4 +131,3 @@ result:SetValues(baseHFt)
 
 logger:Info("Writing source data to file")
 luatool:WriteToFile(result)
-

--- a/himan-scripts/icing-severe-base-top.lua
+++ b/himan-scripts/icing-severe-base-top.lua
@@ -96,7 +96,7 @@ for i=1, #baseM do
 
   -- If height < 15 m, icing should be classified as freezing rain/drizzle (0 m)
   if baseM[i] < 15 then
-    baseFL[i] = 0
+    baseFL[i] = FlightLevel_(p[i])
     baseHFt[i] = 0
   else
     baseFL[i] = FlightLevel_(baseP[i] * 100) -- hPa to Pa

--- a/himan-scripts/icing-severe-base-top.lua
+++ b/himan-scripts/icing-severe-base-top.lua
@@ -7,54 +7,52 @@ Produce it in both flight level and hft coordinates
 ]]
 
 logger:Info("Calculating base and top for severe icing")
-local utils = require("utils")
 
 local IceParam = param("ICING-N")
 
--- We set the vertical search function to work with pressure based vertical coordinate
--- The reasoning is that the pressures can be directly converted into flight levels (FL)
-hitool:SetHeightUnit(HPParameterUnit.kHPa)
+-- We set the vertical search function to work with height based vertical coordinate
+-- The reasoning is that the search range and the freezing rain/drizzle limit are given in meters
+hitool:SetHeightUnit(HPParameterUnit.kM)
+
+-- Highest searched height
+local maxH = 10000
 
 -- Get surface pressure
 local p = luatool:Fetch(current_time, level(HPLevelType.kHeight, 0), param("P-PA"), current_forecast_type)
 
-function BaseHPa(threshold)
-  -- Find the base of icing define as the lowest height / highest pressure at which icing index crosses the threshold value
-  -- returns the height as pressure based coordinate
+function BaseHeight(threshold)
+  -- Find the base of icing define as the lowest height at which icing index crosses the threshold value
+  -- returns the height in meters
 
   local zerodata = {}
-  local pFL300data = {}
+  local maxHdata = {}
   local thresholddata = {}
 
   for i = 1, #p do
-     -- convert surface pressure to hPa
-     zerodata[i] = p[i] / 100
+     zerodata[i] = 0
      thresholddata[i] = threshold
-
-     -- FL300 (30000ft=301hPa)
-     pFL300data[i] = 301
+     maxHdata[i] = maxH
   end
 
-  local basedata = hitool:VerticalHeightGreaterThanGrid(IceParam, zerodata, pFL300data, thresholddata, 1)
+  local basedata = hitool:VerticalHeightGreaterThanGrid(IceParam, zerodata, maxHdata, thresholddata, 1)
 
   return basedata
 end
 
-function TopHPa(threshold,basedata)
-  -- Find the next top above the base of icing define as the height / pressure at which icing index crosses the threshold value
-  -- returns the height as pressure
+function TopHeight(threshold,basedata)
+  -- Find the next top above the base of icing define as the height at which icing index crosses the threshold value
+  -- returns the height in meters
 
-  local pFL300data = {}
+  local maxHdata = {}
   local thresholddata = {}
 
   for i = 1, #basedata do
      thresholddata[i] = threshold
-
-     -- FL300 (30000ft=301hPa)
-     pFL300data[i] = 301
+     maxHdata[i] = maxH
   end
 
-  local topdata = hitool:VerticalHeightLessThanGrid(IceParam, basedata, pFL300data, thresholddata, 1)
+  -- Search is started slightly above the base, otherwise the base itself is returned as the top
+  local topdata = hitool:VerticalHeightLessThanGrid(IceParam, AddScalar(basedata,1), maxHdata, thresholddata, 1)
 
   return topdata
 end
@@ -67,32 +65,50 @@ function AddScalar(arr, scalar)
   return ret
 end
 
-local baseHPa = BaseHPa(6) -- severe icing index >= 7
-local topHPa = TopHPa(7,AddScalar(baseHPa,-1)) -- severe icing index < 7
+-- Base and top are the heights where the interpolated icing index reaches and leaves
+-- the value 7, so that the layer is not padded towards the neighbouring model levels.
+-- The base threshold is nudged just below 7 because the search is done with a strict
+-- comparison (>) and the index is commonly exactly 7 in freezing rain and drizzle.
+local baseM = BaseHeight(7 - 0.001) -- severe icing index >= 7
+local topM = TopHeight(7,baseM) -- severe icing index < 7
 
--- Convert pressure to FL
-local topFL = {}
-local baseFL = {}
-for i=1, #topHPa do
-  topFL[i] = FlightLevel_(topHPa[i] * 100)
-  baseFL[i] = FlightLevel_(baseHPa[i] * 100)
+-- Base and top are always given as a pair
+for i=1, #baseM do
+  if IsMissing(baseM[i]) then
+    topM[i] = missing
+  elseif IsMissing(topM[i]) then
+    -- Icing continues above the searched range
+    topM[i] = maxH
+  end
 end
 
--- Fetch metric heights of base and top to convert them to hFt
-local baseM = hitool:VerticalValueGrid(param("HL-M"), baseHPa)
-local topM = hitool:VerticalValueGrid(param("HL-M"), topHPa)
+-- Fetch pressures of base and top to convert them to FL
+local baseP = hitool:VerticalValueGrid(param("P-HPA"), baseM)
+local topP = hitool:VerticalValueGrid(param("P-HPA"), topM)
 
--- Convert top [M] to hFt
+-- Convert base and top to FL and hFt
+local topFL = {}
+local baseFL = {}
 local topHFt = {}
 local baseHFt = {}
 for i=1, #baseM do
-  -- If height < 15 m, icing should be classified as freezing rain/drizzle (0 m)
-  if baseM[i] < 15 then
-    topHFt[i] = 0
-    baseHFt[i] = 0
+  if IsMissing(baseM[i]) then
+    topFL[i] = missing
+    baseFL[i] = missing
+    topHFt[i] = missing
+    baseHFt[i] = missing
   else
-    topHFt[i] = utils.round(topM[i] / 0.3048 / 100)
-    baseHFt[i] = utils.round(baseM[i] / 0.3048 / 100)
+    topFL[i] = FlightLevel_(topP[i] * 100)
+    topHFt[i] = math.floor(topM[i] / 30.48)
+
+    -- If height < 15 m, icing should be classified as freezing rain/drizzle (0 m)
+    if baseM[i] < 15 then
+      baseFL[i] = FlightLevel_(p[i])
+      baseHFt[i] = 0
+    else
+      baseFL[i] = FlightLevel_(baseP[i] * 100)
+      baseHFt[i] = math.floor(baseM[i] / 30.48)
+    end
   end
 end
 

--- a/himan-scripts/icing-severe-base-top.lua
+++ b/himan-scripts/icing-severe-base-top.lua
@@ -10,9 +10,8 @@ logger:Info("Calculating base and top for severe icing")
 
 local IceParam = param("ICING-N")
 
--- We set the vertical search function to work with height based vertical coordinate
--- The reasoning is that the search range and the freezing rain/drizzle limit are given in meters
-hitool:SetHeightUnit(HPParameterUnit.kM)
+-- The vertical search is done in the default height based coordinate (HL-M),
+-- so the search range and the freezing rain/drizzle limit are given in meters
 
 -- Highest searched height
 local maxH = 10000
@@ -68,7 +67,7 @@ end
 -- Base and top are the heights where the interpolated icing index reaches and leaves
 -- the value 7, so that the layer is not padded towards the neighbouring model levels.
 -- The base threshold is nudged just below 7 because the search is done with a strict
--- comparison (>) and the index is commonly exactly 7 in freezing rain and drizzle.
+-- comparison (>).
 local baseM = BaseHeight(7 - 0.001) -- severe icing index >= 7
 local topM = TopHeight(7,baseM) -- severe icing index < 7
 
@@ -92,23 +91,16 @@ local baseFL = {}
 local topHFt = {}
 local baseHFt = {}
 for i=1, #baseM do
-  if IsMissing(baseM[i]) then
-    topFL[i] = missing
-    baseFL[i] = missing
-    topHFt[i] = missing
-    baseHFt[i] = missing
-  else
-    topFL[i] = FlightLevel_(topP[i] * 100)
-    topHFt[i] = math.floor(topM[i] / 30.48)
+  topFL[i] = FlightLevel_(topP[i] * 100) -- hPa to Pa
+  topHFt[i] = math.ceil(topM[i] / 30.48) -- 0.3048 / 100
 
-    -- If height < 15 m, icing should be classified as freezing rain/drizzle (0 m)
-    if baseM[i] < 15 then
-      baseFL[i] = FlightLevel_(p[i])
-      baseHFt[i] = 0
-    else
-      baseFL[i] = FlightLevel_(baseP[i] * 100)
-      baseHFt[i] = math.floor(baseM[i] / 30.48)
-    end
+  -- If height < 15 m, icing should be classified as freezing rain/drizzle (0 m)
+  if baseM[i] < 15 then
+    baseFL[i] = 0
+    baseHFt[i] = 0
+  else
+    baseFL[i] = FlightLevel_(baseP[i] * 100) -- hPa to Pa
+    baseHFt[i] = math.floor(baseM[i] / 30.48) -- 0.3048 / 100
   end
 end
 


### PR DESCRIPTION
## Severe icing base and top for ILME

Adds a new lua script that produces the base and top of the severe icing layer, and fixes the same base/top search in the existing icing script. Left the flight level rounding out of this PR but I have the code ready.

### New: himan-scripts/icing-severe-base-top.lua

Writes four parameters: `ICING-SEV-BASE-FL`, `ICING-SEV-TOP-FL`, `ICING-SEV-BASE-FT`, `ICING-SEV-TOP-FT`.

The severe icing layer is where the icing index (`ICING-N`) is >= 7. The index is searched on the model hybrid levels in metric height (hitool's default `HL-M` coordinate), from the ground up to 10000 m, with `VerticalHeightGreaterThanGrid` for the base and `VerticalHeightLessThanGrid` for the top, so the returned heights are linearly interpolated between levels.

Details worth reviewing:

* **Base below 15 m is moved to the ground** (0 m / FL000): the icing index at the lowest hybrid level comes from freezing rain or drizzle reaching the surface. This is probably redundant since rounding puts result to 0 any case but kept as a additional guardrail.
* **Rounding is directional** so it cannot narrow the layer: base rounded down, top rounded up. hft uses 1 hft = 30.48 m; FL comes from `P-HPA` interpolated to the found heights and converted with `FlightLevel_`.
* **Base and top are always written as a pair.** If no base is found, the top is missing as well; if the layer continues above the search range, the top is set to 10000 m.

The last commit changes mild icing to match the search for severe icing. Notable changes to `icing-base-top.lua` are:

* Search radius is now exactly 0-10000m. Before it was set to FL300 to approximate metric height.
* Search of icing indices is done in metric heights, which are then converted to hPa to find flight levels.
* Base and top can only exist as pairs.
* Rounding top upwards and bottom downwards instead of the closest value.

### Fix: himan-scripts/icing-base-top.lua

The mild icing base was searched with threshold 3 while the top used 4. That placed the base at a height where the index was still below 4, so the top search starting from there immediately matched at its own lower edge and returned the base as the top — the icing layer came out with zero thickness almost everywhere. The base threshold is now 3.999, i.e. the height where the interpolated index reaches 4.

### Testing

FL top vs base:
```
  grid points            1014481
  both missing            975951  96.20%
  base and top             38530   3.80%
  base without top             0          <- should be 0
  top without base             0          <- should be 0
  base == top              11118  28.86% of the points that have a layer
  top < base                   0          <- should be 0
  top - base           min 0  median 10  max 95
  thickness histogram
      0          11118  28.86%
      1              0   0.00%
      2              0   0.00%
      3-4            0   0.00%
      5-9         3100   8.05%
     10-19        9638  25.01%
     20+         14674  38.08%
```
hft top vs base:
```
  grid points            1014481
  both missing            975951  96.20%
  base and top             38530   3.80%
  base without top             0          <- should be 0
  top without base             0          <- should be 0
  base == top                  0   0.00% of the points that have a layer
  top < base                   0          <- should be 0
  top - base           min 1  median 12  max 97
  thickness histogram
      0              0   0.00%
      1          10690  27.74%
      2            346   0.90%
      3-4          181   0.47%
      5-9         4035  10.47%
     10-19        9268  24.05%
     20+         14010  36.36%
```

**And if we go without rounding FL:**

FL:
```
  grid points            1014481
  both missing            975951  96.20%
  base and top             38530   3.80%
  base without top             0          <- should be 0
  top without base             0          <- should be 0
  base == top                  0   0.00% of the points that have a layer
  top < base                   0          <- should be 0
  top - base           min 1  median 12  max 96
  thickness histogram
      0              0   0.00%
      1          10684  27.73%
      2            352   0.91%
      3-4          186   0.48%
      5-9         4372  11.35%
     10-19        9361  24.30%
     20+         13575  35.23%
```

hft:
```
  grid points            1014481
  both missing            975951  96.20%
  base and top             38530   3.80%
  base without top             0          <- should be 0
  top without base             0          <- should be 0
  base == top                  0   0.00% of the points that have a layer
  top < base                   0          <- should be 0
  top - base           min 1  median 12  max 97
  thickness histogram
      0              0   0.00%
      1          10690  27.74%
      2            346   0.90%
      3-4          181   0.47%
      5-9         4035  10.47%
     10-19        9268  24.05%
     20+         14010  36.36%
```

