### PR TITLE
Add DAYLIGHT-INDEX parameter to smartsymbol

### DIFF
--- a/himan-scripts/daylight.lua
+++ b/himan-scripts/daylight.lua
@@ -1,0 +1,27 @@
+-- Daylight:
+-- Binary parameter telling whether the sun is up (1) or down (0) at the valid time
+-- of the forecast. The limit is the same one that is used for sunrise and sunset
+-- in almanacs: the center of the sun is 50' (0.833 degrees) below the horizon, which
+-- accounts for atmospheric refraction (34') and the radius of the solar disk (16').
+
+logger:Debug("Calculating Daylight")
+
+local sunrise_elevation_angle = -0.833
+
+local validtime = current_time:GetValidDateTime()
+local Daylight = {}
+
+for i=1,result:SizeLocations() do
+  -- Default is night; only points where the sun is up are flipped to daylight.
+  Daylight[i] = 0
+
+  local elevation_angle = ElevationAngle_(result:GetLatLon(i), validtime)
+
+  if elevation_angle > sunrise_elevation_angle then
+    Daylight[i] = 1
+  end
+end
+
+result:SetParam(param("DAYLIGHT-0OR1"))
+result:SetValues(Daylight)
+luatool:WriteToFile(result)

--- a/himan-scripts/smartsymbol.lua
+++ b/himan-scripts/smartsymbol.lua
@@ -32,6 +32,13 @@
 --
 -- Hessaa:
 -- For backwards compatibility, we map WeatherNumber to Hessaa (also called WeatherSymbol3) 
+--
+-- Daylight:
+-- Binary parameter telling whether the sun is up (1) or down (0) at the valid time
+-- of the forecast. Client applications use this to pick between the day and night
+-- variant of a symbol. The limit is the same one that is used for sunrise and sunset
+-- in almanacs: the center of the sun is 50' (0.833 degrees) below the horizon, which
+-- accounts for atmospheric refraction (34') and the radius of the solar disk (16').
 
 local MISS = missing
 local SmartSymbolTable = {}
@@ -397,7 +404,34 @@ function Hessaa(WeatherNumber)
   luatool:WriteToFile(result)
 end
 
+function Daylight()
+  logger:Debug("Calculating Daylight")
+
+  -- Sun is considered to be up when the center of the disk is higher than
+  -- 50 arc minutes below the horizon (same definition as in almanacs).
+  local sunrise_elevation_angle = -0.833
+
+  local validtime = current_time:GetValidDateTime()
+  local Daylight = {}
+
+  for i=1,result:SizeLocations() do
+    -- Default is night; only points where the sun is up are flipped to daylight.
+    Daylight[i] = 0
+
+    local elevation_angle = ElevationAngle_(result:GetLatLon(i), validtime)
+
+    if elevation_angle > sunrise_elevation_angle then
+      Daylight[i] = 1
+    end
+  end
+
+  result:SetParam(param("DAYLIGHT-INDEX"))
+  result:SetValues(Daylight)
+  luatool:WriteToFile(result)
+end
+
 number = WeatherNumber()
+Daylight()
 
 if number then
   SmartSymbol(number)

--- a/himan-scripts/smartsymbol.lua
+++ b/himan-scripts/smartsymbol.lua
@@ -32,13 +32,6 @@
 --
 -- Hessaa:
 -- For backwards compatibility, we map WeatherNumber to Hessaa (also called WeatherSymbol3) 
---
--- Daylight:
--- Binary parameter telling whether the sun is up (1) or down (0) at the valid time
--- of the forecast. Client applications use this to pick between the day and night
--- variant of a symbol. The limit is the same one that is used for sunrise and sunset
--- in almanacs: the center of the sun is 50' (0.833 degrees) below the horizon, which
--- accounts for atmospheric refraction (34') and the radius of the solar disk (16').
 
 local MISS = missing
 local SmartSymbolTable = {}
@@ -404,34 +397,7 @@ function Hessaa(WeatherNumber)
   luatool:WriteToFile(result)
 end
 
-function Daylight()
-  logger:Debug("Calculating Daylight")
-
-  -- Sun is considered to be up when the center of the disk is higher than
-  -- 50 arc minutes below the horizon (same definition as in almanacs).
-  local sunrise_elevation_angle = -0.833
-
-  local validtime = current_time:GetValidDateTime()
-  local Daylight = {}
-
-  for i=1,result:SizeLocations() do
-    -- Default is night; only points where the sun is up are flipped to daylight.
-    Daylight[i] = 0
-
-    local elevation_angle = ElevationAngle_(result:GetLatLon(i), validtime)
-
-    if elevation_angle > sunrise_elevation_angle then
-      Daylight[i] = 1
-    end
-  end
-
-  result:SetParam(param("DAYLIGHT-0OR1"))
-  result:SetValues(Daylight)
-  luatool:WriteToFile(result)
-end
-
 number = WeatherNumber()
-Daylight()
 
 if number then
   SmartSymbol(number)

--- a/himan-scripts/smartsymbol.lua
+++ b/himan-scripts/smartsymbol.lua
@@ -425,7 +425,7 @@ function Daylight()
     end
   end
 
-  result:SetParam(param("DAYLIGHT-INDEX"))
+  result:SetParam(param("DAYLIGHT-0OR1"))
   result:SetValues(Daylight)
   luatool:WriteToFile(result)
 end


### PR DESCRIPTION
SmartSymbol itself carries no day/night information; picking between the day and night variant of a symbol has been left to client applications. Write the daylight flag out explicitly as its own binary parameter.

The sun is considered to be up when its elevation angle exceeds -0.833 degrees, the same limit almanacs use for sunrise and sunset (refraction 34' + solar disk radius 16'). Compared against a Meeus/NOAA solar position, metutil::ElevationAngle_ places sunrise and sunset within ~3 minutes in southern and central Finland, so it is accurate enough here. In Lapland the error grows to 5-15 minutes, and the first and last day of polar day/night can be off by one day, because the sun grazes the horizon at a shallow angle there.