### PR TITLE
Update ICAO weather code to v2.1

### DIFF
--- a/himan-scripts/CB-TCU-base.lua
+++ b/himan-scripts/CB-TCU-base.lua
@@ -10,7 +10,7 @@ local HG = level(HPLevelType.kHeight, 0)
 local CBTCU_FL = luatool:Fetch(current_time, HG, param("CBTCU-FL"), current_forecast_type)
 local LCL500 = luatool:Fetch(current_time, HL, param("LCL-M"), current_forecast_type)
 local LCLmu = luatool:Fetch(current_time, MU, param("LCL-M"), current_forecast_type)
-local ProbCb = luatool:Fetch(current_time, HG, param("PROB-CBTCU-1"), current_forecast_type)
+local ProbCb = luatool:Fetch(current_time, HG, param("PROB-CBTCU-1"), forecast_type(HPForecastType.kStatisticalProcessing))
 
 -- skip optional ProbCb
 if not CBTCU_FL or not LCL500 or not LCLmu then

--- a/himan-scripts/ICAO-wx.lua
+++ b/himan-scripts/ICAO-wx.lua
@@ -60,7 +60,13 @@ local PreFormdata = luatool:Fetch(current_time, current_level, PreForm, current_
 local visibdata = luatool:Fetch(current_time, current_level, visib, current_forecast_type)
 local POTdata = luatool:Fetch(current_time, current_level, POT, current_forecast_type)
 local cbdata = luatool:Fetch(current_time, current_level, cb, current_forecast_type)
-local CAPEmdata = luatool:Fetch(current_time, current_level, CAPEm, current_forecast_type)
+-- use most-unstable CAPE for EC, surface level for MEPS
+local CAPEmdata
+if (configuration:GetTargetProducer():GetId() == 240) then
+  CAPEmdata = luatool:Fetch(current_time, level(HPLevelType.kMaximumThetaE, 0), CAPEm, current_forecast_type)
+else
+  CAPEmdata = luatool:Fetch(current_time, current_level, CAPEm, current_forecast_type)
+end
 local BSdata = luatool:Fetch(current_time, level(HPLevelType.kHeightLayer,6000,0), BS, current_forecast_type)
 local Tdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,2), t, current_forecast_type)
 

--- a/himan-scripts/ICAO-wx.lua
+++ b/himan-scripts/ICAO-wx.lua
@@ -130,7 +130,7 @@ local areaMaxCB = Max2D(Nmat,filter,configuration:GetUseCuda()):GetValues()
 local rrLim = 0.04
 
 -- Relative humidity threshold [%] for (freezing) misty/foggy conditions in precipitation
-local rhMoist = 95
+local rhMoist = 0.95
 
 -- Threshold for showery precipitation (may need tweaking) [J/kg]
 local shCAPE = 10

--- a/himan-scripts/ICAO-wx.lua
+++ b/himan-scripts/ICAO-wx.lua
@@ -51,8 +51,8 @@ local t = param("T-K")
 -- skin temperature
 local t0m = param("SKT-K")
 
--- 2m relative humidity (%)
-local RH = param("RH-PRCNT")
+-- relative humidity (%)
+local RH = param("RH-0TO1")
 
 -- wind speed
 local ws = param("FF-MS")

--- a/himan-scripts/ICAO-wx.lua
+++ b/himan-scripts/ICAO-wx.lua
@@ -4,6 +4,69 @@
 -- Combined code = base code + 100 (FG) / 200 (FZFG) / 300 (BR) / 400 (DRSN) / 500 (BLSN).
 -- Ported from icao-smartool v2.0.
 
+
+-- Mean 2m temperature of the past hours (dry-snow check for DRSN/BLSN).
+-- Radon has no time aggregated T-K -- and asking for one silently returns the
+-- instantaneous field -- so the mean is calculated here from the instantaneous
+-- 2m temperatures of the current and the preceding hours. Hours that are before
+-- the analysis time are read from an older forecast, hours that are not found
+-- at all are left out of the mean.
+local function MeanTemperature(hours)
+  local sum = nil
+  local count = 0
+
+  for h=0, hours-1 do
+    local ftime = forecast_time(current_time)
+    ftime:GetValidDateTime():Adjust(HPTimeResolution.kHourResolution, -h)
+
+    -- valid time is before the analysis time: use an older analysis time
+    local step = ftime:GetStep():Hours()
+
+    if (step < 0) then
+      local adjustment = math.ceil(-step / runInterval) * runInterval
+      ftime:GetOriginDateTime():Adjust(HPTimeResolution.kHourResolution, -adjustment)
+    end
+
+    local data = luatool:Fetch(ftime, level2m, t, current_forecast_type)
+
+    if data then
+      if (sum == nil) then
+        sum = {}
+        for i=1, #data do
+          sum[i] = 0
+        end
+      end
+
+      for i=1, #data do
+        sum[i] = sum[i] + data[i]
+      end
+
+      count = count + 1
+    else
+      logger:Warning(string.format("2m temperature not found for -%dh, leaving it out of the %dh mean", h, hours))
+    end
+  end
+
+  if (count == 0) then
+    logger:Error(string.format("No 2m temperature found for the %dh mean", hours))
+    error("luatool:Fetch failed")
+  end
+
+  -- with a single hour the "mean" is the instantaneous temperature, which makes
+  -- the dry-snow check weaker but still produces data for the time step
+  if (count == 1) then
+    logger:Warning(string.format("Only 1 of %d hours found, using the instantaneous 2m temperature", hours))
+  end
+
+  local mean = {}
+
+  for i=1, #sum do
+    mean[i] = sum[i] / count
+  end
+
+  return mean
+end
+
 local MISS = missing
 
 -- producer ids
@@ -101,68 +164,6 @@ end
 local BSdata = luatool:Fetch(current_time, level(HPLevelType.kHeightLayer,6000,0), BS, current_forecast_type)
 local Tdata = luatool:Fetch(current_time, level2m, t, current_forecast_type)
 local RHdata = luatool:Fetch(current_time, level2m, RH, current_forecast_type)
-
--- Mean 2m temperature of the past hours (dry-snow check for DRSN/BLSN).
--- Radon has no time aggregated T-K -- and asking for one silently returns the
--- instantaneous field -- so the mean is calculated here from the instantaneous
--- 2m temperatures of the current and the preceding hours. Hours that are before
--- the analysis time are read from an older forecast, hours that are not found
--- at all are left out of the mean.
-local function MeanTemperature(hours)
-  local sum = nil
-  local count = 0
-
-  for h=0, hours-1 do
-    local ftime = forecast_time(current_time)
-    ftime:GetValidDateTime():Adjust(HPTimeResolution.kHourResolution, -h)
-
-    -- valid time is before the analysis time: use an older analysis time
-    local step = ftime:GetStep():Hours()
-
-    if (step < 0) then
-      local adjustment = math.ceil(-step / runInterval) * runInterval
-      ftime:GetOriginDateTime():Adjust(HPTimeResolution.kHourResolution, -adjustment)
-    end
-
-    local data = luatool:Fetch(ftime, level2m, t, current_forecast_type)
-
-    if data then
-      if (sum == nil) then
-        sum = {}
-        for i=1, #data do
-          sum[i] = 0
-        end
-      end
-
-      for i=1, #data do
-        sum[i] = sum[i] + data[i]
-      end
-
-      count = count + 1
-    else
-      logger:Warning(string.format("2m temperature not found for -%dh, leaving it out of the %dh mean", h, hours))
-    end
-  end
-
-  if (count == 0) then
-    logger:Error(string.format("No 2m temperature found for the %dh mean", hours))
-    error("luatool:Fetch failed")
-  end
-
-  -- with a single hour the "mean" is the instantaneous temperature, which makes
-  -- the dry-snow check weaker but still produces data for the time step
-  if (count == 1) then
-    logger:Warning(string.format("Only 1 of %d hours found, using the instantaneous 2m temperature", hours))
-  end
-
-  local mean = {}
-
-  for i=1, #sum do
-    mean[i] = sum[i] / count
-  end
-
-  return mean
-end
 
 local Tavgdata = MeanTemperature(TavgHours)
 

--- a/himan-scripts/ICAO-wx.lua
+++ b/himan-scripts/ICAO-wx.lua
@@ -60,8 +60,15 @@ local ws = param("FF-MS")
 -- wind gust
 local wg = param("FFG-MS", aggregation(HPAggregationType.kMaximum, time_duration(HPTimeResolution.kHourResolution, 1)), processing_type())
 
--- past 5 hours' average 2m temperature (dry-snow check for DRSN/BLSN)
-local Tavg = param("T-K", aggregation(HPAggregationType.kAverage, time_duration(HPTimeResolution.kHourResolution, 5)), processing_type())
+-- length of the averaging window of the 2m temperature (dry-snow check for DRSN/BLSN) [h]
+local TavgHours = 5
+
+-- analysis time interval of the producer [h], needed when the averaging window
+-- reaches over the analysis time and an older forecast has to be used
+local runInterval = 12
+if (configuration:GetTargetProducer():GetId() == 260) then
+  runInterval = 3
+end
 
 -- fetch input params
 local PreIntdata = luatool:Fetch(current_time, current_level, PreInt, current_forecast_type)
@@ -80,7 +87,70 @@ end
 local BSdata = luatool:Fetch(current_time, level(HPLevelType.kHeightLayer,6000,0), BS, current_forecast_type)
 local Tdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,2), t, current_forecast_type)
 local RHdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,2), RH, current_forecast_type)
-local Tavgdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,2), Tavg, current_forecast_type)
+
+-- Mean 2m temperature of the past hours (dry-snow check for DRSN/BLSN).
+-- Radon has no time aggregated T-K -- and asking for one silently returns the
+-- instantaneous field -- so the mean is calculated here from the instantaneous
+-- 2m temperatures of the current and the preceding hours. Hours that are before
+-- the analysis time are read from an older forecast, hours that are not found
+-- at all are left out of the mean.
+local function MeanTemperature(hours)
+  local sum = nil
+  local count = 0
+
+  for h=0, hours-1 do
+    local ftime = forecast_time(current_time)
+    ftime:GetValidDateTime():Adjust(HPTimeResolution.kHourResolution, -h)
+
+    -- valid time is before the analysis time: use an older analysis time
+    local step = ftime:GetStep():Hours()
+
+    if (step < 0) then
+      local adjustment = math.ceil(-step / runInterval) * runInterval
+      ftime:GetOriginDateTime():Adjust(HPTimeResolution.kHourResolution, -adjustment)
+    end
+
+    local data = luatool:Fetch(ftime, level(HPLevelType.kHeight,2), t, current_forecast_type)
+
+    if data then
+      if (sum == nil) then
+        sum = {}
+        for i=1, #data do
+          sum[i] = 0
+        end
+      end
+
+      for i=1, #data do
+        sum[i] = sum[i] + data[i]
+      end
+
+      count = count + 1
+    else
+      logger:Warning(string.format("2m temperature not found for -%dh, leaving it out of the %dh mean", h, hours))
+    end
+  end
+
+  if (count == 0) then
+    logger:Error(string.format("No 2m temperature found for the %dh mean", hours))
+    error("luatool:Fetch failed")
+  end
+
+  -- with a single hour the "mean" is the instantaneous temperature, which makes
+  -- the dry-snow check weaker but still produces data for the time step
+  if (count == 1) then
+    logger:Warning(string.format("Only 1 of %d hours found, using the instantaneous 2m temperature", hours))
+  end
+
+  local mean = {}
+
+  for i=1, #sum do
+    mean[i] = sum[i] / count
+  end
+
+  return mean
+end
+
+local Tavgdata = MeanTemperature(TavgHours)
 
 local TGdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,0), t, current_forecast_type)
 -- for EC fetch param skin temperature

--- a/himan-scripts/ICAO-wx.lua
+++ b/himan-scripts/ICAO-wx.lua
@@ -347,7 +347,7 @@ for i=1, #PreIntdata do
           wx[i] = 86
         end
         -- Thunderstorm and wet sleet
-        if (POTdata[i] > TSlim and cbdata > CbTSlim) then
+        if (POTdata[i] > TSlim and cbdata[i] > CbTSlim) then
           -- -TSRASN
           wx[i] = 33
           -- TSRASN
@@ -478,11 +478,11 @@ for i=1, #PreIntdata do
     -- -SG
     wx[i] = 75
     -- SG
-    if (PreIntdata[i] > ModSGLim) then
+    if (PreIntdata[i] > ModSGlim) then
       wx[i] = 76
     end
     -- +SG
-    if (PreIntdata[i] > HvySGLim) then
+    if (PreIntdata[i] > HvySGlim) then
       wx[i] = 77
     end
   end

--- a/himan-scripts/ICAO-wx.lua
+++ b/himan-scripts/ICAO-wx.lua
@@ -6,13 +6,27 @@
 
 local MISS = missing
 
+-- producer ids
+local ECGMTA = 240
+local MEPSMTA = 260
+
+local producerId = configuration:GetTargetProducer():GetId()
+
+-- commonly used levels
+local level2m = level(HPLevelType.kHeight, 2)
+local level10m = level(HPLevelType.kHeight, 10)
+local levelGround = level(HPLevelType.kHeight, 0)
+
+-- freezing point [K]
+local T0 = 273.15
+
 -- precipitation intensity mm/h
 local PreInt = param("RRR-KGM2")
 
 -- snowfall intensity mm/h
 -- use solid precipitation rate for MEPS
 local Snow
-if (configuration:GetTargetProducer():GetId() == 260) then
+if (producerId == MEPSMTA) then
   Snow = param("RRRS-KGM2")
 else
   Snow = param("SNR-KGM2")
@@ -21,7 +35,7 @@ end
 -- snow accumulation
 -- use solid precipitation rate for MEPS
 local Snacc
-if (configuration:GetTargetProducer():GetId() == 260) then
+if (producerId == MEPSMTA) then
   Snacc = param("RRS-12-MM")
 else
   Snacc = param("SN-12-MM")
@@ -66,7 +80,7 @@ local TavgHours = 5
 -- analysis time interval of the producer [h], needed when the averaging window
 -- reaches over the analysis time and an older forecast has to be used
 local runInterval = 12
-if (configuration:GetTargetProducer():GetId() == 260) then
+if (producerId == MEPSMTA) then
   runInterval = 3
 end
 
@@ -79,14 +93,14 @@ local POTdata = luatool:Fetch(current_time, current_level, POT, current_forecast
 local cbdata = luatool:Fetch(current_time, current_level, cb, current_forecast_type)
 -- use most-unstable CAPE for EC, surface level for MEPS
 local CAPEmdata
-if (configuration:GetTargetProducer():GetId() == 240) then
+if (producerId == ECGMTA) then
   CAPEmdata = luatool:Fetch(current_time, level(HPLevelType.kMaximumThetaE, 0), CAPEm, current_forecast_type)
 else
   CAPEmdata = luatool:Fetch(current_time, current_level, CAPEm, current_forecast_type)
 end
 local BSdata = luatool:Fetch(current_time, level(HPLevelType.kHeightLayer,6000,0), BS, current_forecast_type)
-local Tdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,2), t, current_forecast_type)
-local RHdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,2), RH, current_forecast_type)
+local Tdata = luatool:Fetch(current_time, level2m, t, current_forecast_type)
+local RHdata = luatool:Fetch(current_time, level2m, RH, current_forecast_type)
 
 -- Mean 2m temperature of the past hours (dry-snow check for DRSN/BLSN).
 -- Radon has no time aggregated T-K -- and asking for one silently returns the
@@ -110,7 +124,7 @@ local function MeanTemperature(hours)
       ftime:GetOriginDateTime():Adjust(HPTimeResolution.kHourResolution, -adjustment)
     end
 
-    local data = luatool:Fetch(ftime, level(HPLevelType.kHeight,2), t, current_forecast_type)
+    local data = luatool:Fetch(ftime, level2m, t, current_forecast_type)
 
     if data then
       if (sum == nil) then
@@ -152,14 +166,14 @@ end
 
 local Tavgdata = MeanTemperature(TavgHours)
 
-local TGdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,0), t, current_forecast_type)
+local TGdata = luatool:Fetch(current_time, levelGround, t, current_forecast_type)
 -- for EC fetch param skin temperature
-if (configuration:GetTargetProducer():GetId() == 240) then
+if (producerId == ECGMTA) then
     TGdata = luatool:Fetch(current_time, level(HPLevelType.kGround,0), t0m, current_forecast_type)
 end
 
-local wsdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,10), ws, current_forecast_type)
-local wgdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,10), wg, current_forecast_type)
+local wsdata = luatool:Fetch(current_time, level10m, ws, current_forecast_type)
+local wgdata = luatool:Fetch(current_time, level10m, wg, current_forecast_type)
 
 -- fetch snow accumulation
 -- Use older analysis time if not enough time steps are available for 12 accumulation period
@@ -167,12 +181,9 @@ local Snaccdata
 if (current_time:GetStep():Hours() < 12) then
   local new_time = forecast_time(current_time)
 
-  -- set origin time adjustment depending on producer, default -12h
-  -- for meps we adjust in steps of 3h
-  local adjustment = -12
-  if (configuration:GetTargetProducer():GetId() == 260) then
-    adjustment = math.floor(current_time:GetStep():Hours()/3) * 3 - 12
-  end
+  -- take the origin time back by the accumulation period, rounded to whole
+  -- analysis times of the producer (12h for EC, 3h for MEPS)
+  local adjustment = math.floor(current_time:GetStep():Hours()/runInterval) * runInterval - 12
 
   new_time:GetOriginDateTime():Adjust(HPTimeResolution.kHourResolution, adjustment)
   Snaccdata = luatool:Fetch(new_time,current_level,Snacc,current_forecast_type)
@@ -183,9 +194,9 @@ end
 
 -- calculate area_max fields with ~30km box
 local filter
-if (configuration:GetTargetProducer():GetId() == 260) then
+if (producerId == MEPSMTA) then
   filter = matrixf(12, 12, 1, 1)
-elseif (configuration:GetTargetProducer():GetId() == 240) then
+elseif (producerId == ECGMTA) then
   filter = matrixf(3, 3, 1, 1)
 end
 
@@ -283,7 +294,7 @@ for i=1, #PreIntdata do
   end
 
   -- Freezing fog FZFG
-  if ((visibdata[i] < 1000) and (Tdata[i] < 273.15)) then
+  if ((visibdata[i] < 1000) and (Tdata[i] < T0)) then
     wx[i] = 12
   end
 
@@ -417,7 +428,7 @@ for i=1, #PreIntdata do
 
     -- TS FG/FZFG
     if (wx[i] < 100 and visibdata[i] < 1000) then
-      if (Tdata[i] >= 273.15) then
+      if (Tdata[i] >= T0) then
         wx[i] = wx[i] + 100
       else
         wx[i] = wx[i] + 200
@@ -529,13 +540,13 @@ for i=1, #PreIntdata do
   -- Tsfc to discard open water areas (no ice), Tavg to discard wet-snow cases
   -- DRSN
   if (Snaccdata ~= nil) then
-    if (Snaccdata[i] > DRSNlim and wsdata[i] >= 6 and Tdata[i] < 273.15 and TGdata[i] < 273.15 and Tavgdata[i] < 273.15) then
+    if (Snaccdata[i] > DRSNlim and wsdata[i] >= 6 and Tdata[i] < T0 and TGdata[i] < T0 and Tavgdata[i] < T0) then
       DRBL = 15
       wx[i] = DRBL
     end
 
     -- BLSN
-    if (Snaccdata[i] > DRSNlim and wsdata[i] >= BLSNwind and wgdata[i] >=BLSNgust and Tdata[i] < 273.15 and TGdata[i] < 273.15 and Tavgdata[i] < 273.15) then
+    if (Snaccdata[i] > DRSNlim and wsdata[i] >= BLSNwind and wgdata[i] >=BLSNgust and Tdata[i] < T0 and TGdata[i] < T0 and Tavgdata[i] < T0) then
       DRBL = 16
       wx[i] = DRBL
     end
@@ -593,7 +604,7 @@ for i=1, #PreIntdata do
 
     -- -SN/-SHSN/-TSSN FG/FZFG, only if DRSN/BLSN wasn't already added (+ variants not allowed)
     if ((wx[i] == 72 or wx[i] == 90 or wx[i] == 26) and visibdata[i] < 1000 and RHdata[i] > rhMoist) then
-      if (Tdata[i] >= 273.15) then
+      if (Tdata[i] >= T0) then
         wx[i] = wx[i] + 100
       else
         wx[i] = wx[i] + 200

--- a/himan-scripts/ICAO-wx.lua
+++ b/himan-scripts/ICAO-wx.lua
@@ -1,4 +1,8 @@
 -- ICAO TAF/METAR weather code (WX) mapping to numbers from model data (to be used in ADF/AMFIS tool)
+--
+-- v2.0: may return a code for two WX phenomena (precipitation + fog/mist, or snow + drifting/blowing snow).
+-- Combined code = base code + 100 (FG) / 200 (FZFG) / 300 (BR) / 400 (DRSN) / 500 (BLSN).
+-- Ported from icao-smartool v2.0.
 
 local MISS = missing
 
@@ -29,7 +33,7 @@ local PreForm = param("PRECFORM2-N")
 -- visibility FMI (m)
 local visib = param("VV2-M")
 
--- POT FMI 
+-- POT FMI
 local POT = param("POT-PRCNT")
 
 -- CbTCu top FMI (FL)
@@ -47,11 +51,17 @@ local t = param("T-K")
 -- skin temperature
 local t0m = param("SKT-K")
 
+-- 2m relative humidity (%)
+local RH = param("RH-PRCNT")
+
 -- wind speed
 local ws = param("FF-MS")
 
 -- wind gust
 local wg = param("FFG-MS", aggregation(HPAggregationType.kMaximum, time_duration(HPTimeResolution.kHourResolution, 1)), processing_type())
+
+-- past 5 hours' average 2m temperature (dry-snow check for DRSN/BLSN)
+local Tavg = param("T-K", aggregation(HPAggregationType.kAverage, time_duration(HPTimeResolution.kHourResolution, 5)), processing_type())
 
 -- fetch input params
 local PreIntdata = luatool:Fetch(current_time, current_level, PreInt, current_forecast_type)
@@ -69,6 +79,8 @@ else
 end
 local BSdata = luatool:Fetch(current_time, level(HPLevelType.kHeightLayer,6000,0), BS, current_forecast_type)
 local Tdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,2), t, current_forecast_type)
+local RHdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,2), RH, current_forecast_type)
+local Tavgdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,2), Tavg, current_forecast_type)
 
 local TGdata = luatool:Fetch(current_time, level(HPLevelType.kHeight,0), t, current_forecast_type)
 -- for EC fetch param skin temperature
@@ -115,7 +127,10 @@ local areaMaxCB = Max2D(Nmat,filter,configuration:GetUseCuda()):GetValues()
 
 -- set constants
 -- rr limit for MEPS (which has large areas of near zero hourly precipitation)
-local rrLim = 0
+local rrLim = 0.04
+
+-- Relative humidity threshold [%] for (freezing) misty/foggy conditions in precipitation
+local rhMoist = 95
 
 -- Threshold for showery precipitation (may need tweaking) [J/kg]
 local shCAPE = 10
@@ -142,7 +157,11 @@ local HvyDzLim = 0.2
 local ModRaLim = 1
 local HvyRaLim = 4
 
--- Limit for moderate/heavy sleet [mm/h]
+-- Limit for moderate/heavy "wet" sleet (RASN) [mm/h]
+local ModRaSleetLim = 1
+local HvyRaSleetLim = 2.5
+
+-- Limit for moderate/heavy "snowy" sleet (SNRA) [mm/h]
 local ModSleetLim = 0.7
 local HvySleetLim = 1.5
 
@@ -198,7 +217,7 @@ for i=1, #PreIntdata do
     wx[i] = 12
   end
 
-  -- Drizzle
+  -- Drizzle, possibly with mist/fog
   if (PreFormdata[i] == 0) then
     -- -DZ
     wx[i] = 50
@@ -210,9 +229,19 @@ for i=1, #PreIntdata do
     if (PreIntdata[i] > HvyDzLim) then
       wx[i] = 52
     end
+
+    -- -DZ BR (DZ/+DZ BR not included due to already misty visibility caused by drizzle)
+    if (wx[i] == 50 and visibdata[i] >= 1000 and visibdata[i] < 5000 and RHdata[i] > rhMoist) then
+      wx[i] = wx[i] + 300
+    end
+
+    -- -DZ/DZ/+DZ FG
+    if (wx[i] < 100 and visibdata[i] < 1000 and RHdata[i] > rhMoist) then
+      wx[i] = wx[i] + 100
+    end
   end
 
-  -- Rain
+  -- Rain, possibly with thunderstorm and/or fog/mist
   if ((PreFormdata[i] == 1) and (PreIntdata[i] > rrLim)) then
     -- continuous rain
     if (PreType == 1) then
@@ -295,14 +324,38 @@ for i=1, #PreIntdata do
         end
       end
     end
+
+    -- -RA/-SHRA/-TSRA/-TSGR BR (moderate/heavy rain not considered due to highly variable visibility in them)
+    if ((wx[i] == 20 or wx[i] == 23 or wx[i] == 60 or wx[i] == 81) and visibdata[i] >= 1000 and visibdata[i] < 5000 and RHdata[i] > rhMoist) then
+      wx[i] = wx[i] + 300
+    end
+
+    -- -RA/RA/+RA/-SHRA/SHRA/+SHRA/-TSRA/TSRA/+TSRA/-TSGR/TSGR/+TSGR FG
+    if (wx[i] < 100 and visibdata[i] < 1000 and RHdata[i] > rhMoist) then
+      wx[i] = wx[i] + 100
+    end
   end
 
-  -- TS (thunderstorm nearby within 8km of the airport, but no precipitation) = 32
+  -- TS (thunderstorm nearby within 8km of the airport, but no precipitation), possibly with mist/fog = 32
   if (PreIntdata[i] == 0 and areaMaxPOT[i] > TSlim and areaMaxCB[i] > CbTSlim) then
     wx[i] = 32
+
+    -- TS BR
+    if (visibdata[i] >= 1000 and visibdata[i] < 5000) then
+      wx[i] = wx[i] + 300
+    end
+
+    -- TS FG/FZFG
+    if (wx[i] < 100 and visibdata[i] < 1000) then
+      if (Tdata[i] >= 273.15) then
+        wx[i] = wx[i] + 100
+      else
+        wx[i] = wx[i] + 200
+      end
+    end
   end
 
-  -- Sleet (possibly with thunderstorms)
+  -- Sleet (possibly with thunderstorms and/or fog)
   if ((PreFormdata[i] == 2) and (PreIntdata[i] > rrLim)) then
     -- continuous
     if (PreType == 1) then
@@ -311,11 +364,11 @@ for i=1, #PreIntdata do
         -- -RASN
         wx[i] = 66
         -- RASN
-        if (PreIntdata[i] > ModSleetLim) then
+        if (PreIntdata[i] > ModRaSleetLim) then
           wx[i] = 67
         end
         -- +RASN
-        if (PreIntdata[i] > HvySleetLim) then
+        if (PreIntdata[i] > HvyRaSleetLim) then
           wx[i] = 68
         end
 
@@ -332,6 +385,11 @@ for i=1, #PreIntdata do
           wx[i] = 71
         end
       end
+
+      -- -RASN/-SNRA FG (RASN/+RASN/SNRA/+SNRA FG not allowed)
+      if ((wx[i] == 66 or wx[i] == 69) and visibdata[i] < 1000 and RHdata[i] > rhMoist) then
+        wx[i] = wx[i] + 100
+      end
     end
     if (PreType == 2) then
       -- wet sleet shower
@@ -339,11 +397,11 @@ for i=1, #PreIntdata do
         -- -SHRASN
         wx[i] = 84
         -- SHRASN
-        if (PreIntdata[i] > ModSleetLim) then
+        if (PreIntdata[i] > ModRaSleetLim) then
           wx[i] = 85
         end
         -- +SHRASN
-        if (PreIntdata[i] > HvySleetLim) then
+        if (PreIntdata[i] > HvyRaSleetLim) then
           wx[i] = 86
         end
         -- Thunderstorm and wet sleet
@@ -351,11 +409,11 @@ for i=1, #PreIntdata do
           -- -TSRASN
           wx[i] = 33
           -- TSRASN
-          if (PreIntdata[i] > ModSleetLim) then
+          if (PreIntdata[i] > ModRaSleetLim) then
             wx[i] = 34
           end
           -- +TSRASN
-          if (PreIntdata[i] > HvySleetLim) then
+          if (PreIntdata[i] > HvyRaSleetLim) then
             wx[i] = 35
           end
         end
@@ -385,24 +443,35 @@ for i=1, #PreIntdata do
           end
         end
       end
+
+      -- -SHRASN/-TSRASN/-SHSNRA/-TSSNRA FG (+ variants not allowed)
+      if ((wx[i] == 84 or wx[i] == 33 or wx[i] == 87 or wx[i] == 36) and visibdata[i] < 1000 and RHdata[i] > rhMoist) then
+        wx[i] = wx[i] + 100
+      end
     end
   end
 
+  
+  -- set when DRSN/BLSN applies, so Snow section can combine it with the precipitation code
+  local DRBL = missing
+
   -- Simplified guesses for DRSN/BLSN
-  -- Tsfc to discard open water areas (no ice)
+  -- Tsfc to discard open water areas (no ice), Tavg to discard wet-snow cases
   -- DRSN
   if (Snaccdata ~= nil) then
-    if (Snaccdata[i] > DRSNlim and wsdata[i] >= 6 and Tdata[i] < 273.15 and TGdata[i] < 273.15) then
-      wx[i] = 15
+    if (Snaccdata[i] > DRSNlim and wsdata[i] >= 6 and Tdata[i] < 273.15 and TGdata[i] < 273.15 and Tavgdata[i] < 273.15) then
+      DRBL = 15
+      wx[i] = DRBL
     end
 
     -- BLSN
-    if (Snaccdata[i] > DRSNlim and wsdata[i] >= BLSNwind and wgdata[i] >=BLSNgust and Tdata[i] < 273.15 and TGdata[i] < 273.15) then
-      wx[i] = 16
+    if (Snaccdata[i] > DRSNlim and wsdata[i] >= BLSNwind and wgdata[i] >=BLSNgust and Tdata[i] < 273.15 and TGdata[i] < 273.15 and Tavgdata[i] < 273.15) then
+      DRBL = 16
+      wx[i] = DRBL
     end
   end
 
-  --Snow (possibly with thunderstorms)
+  --Snow (possibly with thunderstorm and/or drifting/blowing snow or fog)
   if ((PreFormdata[i] == 3) and (PreIntdata[i] > rrLim)) then
     --continuous
     if (PreType == 1) then
@@ -443,9 +512,26 @@ for i=1, #PreIntdata do
         wx[i] = 28
       end
     end
+
+    -- add DRSN/BLSN when applicable
+    if (DRBL == 15) then
+      wx[i] = wx[i] + 400
+    end
+    if (DRBL == 16) then
+      wx[i] = wx[i] + 500
+    end
+
+    -- -SN/-SHSN/-TSSN FG/FZFG, only if DRSN/BLSN wasn't already added (+ variants not allowed)
+    if ((wx[i] == 72 or wx[i] == 90 or wx[i] == 26) and visibdata[i] < 1000 and RHdata[i] > rhMoist) then
+      if (Tdata[i] >= 273.15) then
+        wx[i] = wx[i] + 100
+      else
+        wx[i] = wx[i] + 200
+      end
+    end
   end
 
-  -- Freezing Drizzle
+  -- Freezing Drizzle, possibly with mist or freezing fog
   if (PreFormdata[i] == 4) then
     -- -FZDZ
     wx[i] = 53
@@ -457,9 +543,19 @@ for i=1, #PreIntdata do
     if (PreIntdata[i] > HvyFzdzLim) then
       wx[i] = 55
     end
+
+    -- -FZDZ BR (FZDZ/+FZDZ BR not included due to already misty visibility caused by drizzle)
+    if (wx[i] == 53 and visibdata[i] >= 1000 and visibdata[i] < 5000) then
+      wx[i] = wx[i] + 300
+    end
+
+    -- -FZDZ/FZDZ/+FZDZ FZFG
+    if (wx[i] < 100 and visibdata[i] < 1000) then
+      wx[i] = wx[i] + 200
+    end
   end
 
-  -- Freezing Rain
+  -- Freezing Rain, possibly with mist or freezing fog
   if (PreFormdata[i] == 5) then
     -- -FZRA
     wx[i] = 63
@@ -470,6 +566,16 @@ for i=1, #PreIntdata do
     -- +FZRA
     if (PreIntdata[i] > HvyFzraLim) then
       wx[i] = 65
+    end
+
+    -- -FZRA BR (FZRA/+FZRA not included due to highly variable visibility in them)
+    if (wx[i] == 63 and visibdata[i] >= 1000 and visibdata[i] < 5000) then
+      wx[i] = wx[i] + 300
+    end
+
+    -- -FZRA/FZRA/+FZRA FZFG
+    if (wx[i] < 100 and visibdata[i] < 1000) then
+      wx[i] = wx[i] + 200
     end
   end
 

--- a/himan-scripts/freezing-levels.lua
+++ b/himan-scripts/freezing-levels.lua
@@ -6,9 +6,9 @@ local utils = require("utils")
 local t_param = param("T-K")
 local fzT = 273.15
 
-local first  = hitool:VerticalHeight(t_param, 0, 15000, fzT, 1)
-local second = hitool:VerticalHeight(t_param, 0, 15000, fzT, 2)
-local last   = hitool:VerticalHeight(t_param, 0, 15000, fzT, 0)
+local first  = hitool:VerticalHeight(t_param, 0, 9000, fzT, 1)
+local second = hitool:VerticalHeight(t_param, 0, 9000, fzT, 2)
+local last   = hitool:VerticalHeight(t_param, 0, 9000, fzT, 0)
 
 for i = 1, #first do
   first[i]  = utils.round(first[i]  / 0.3048)


### PR DESCRIPTION
Adds possibility to return two-part weather codes, details: https://jira.fmi.fi/browse/STU-30481

Also couple small adjustments to previous scripts:
- CBTCU cloud base: the script now finds optional PROB-CBTCU-1 parameter correctly.
- Search of freezing levels is now limited to 9000 (spec) instead of 15000.